### PR TITLE
Added note block to review.yml with message about PPO type

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -11,6 +11,18 @@ question: |
   Review your answers
 review:
   - note: |
+      % if defined('ppo_type'):
+      You are filling out a petition for a
+      % if ppo_type == "domestic":
+      *domestic*
+      % elif ppo_type == "nondomestic":
+      *non-domestic*
+      % elif ppo_type == "nondomestic_sexual_assault":
+      *non-domestic sexual assault*
+      % endif
+      PPO. To change the petition type, use the **Undo** button or start over.
+      % endif
+  - note: |
       % if not defined('docket_number'):
       ${ review_empty_explainer }
       % endif


### PR DESCRIPTION
- Fixes #242 
- Note appears at the top of the review screen when the value of ppo_type has been defined, letting user know the type of PPO they're filling out and that they can use the Undo button to change it. 