### PR TITLE
Added logic to update_pending_actions and update_orders_judgments blocks

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1001,8 +1001,12 @@ code: |
   if not pending_actions.there_are_any:
     pending_actions.clear()
     pending_actions.there_are_any = False
+    pending_actions_between_parties_no = True
+    pending_actions_between_parties_yes = False
   else:
     pending_actions.there_are_any = True
+    pending_actions_between_parties_yes = True
+    pending_actions_between_parties_no = False
 
   update_pending_actions = True
 ---
@@ -1010,8 +1014,12 @@ code: |
   if not orders_judgments.there_are_any:
     orders_judgments.clear()
     orders_judgments.there_are_any = False
+    orders_judgments_re_parties_yes = False
+    orders_judgments_re_parties_no = True
   else:
     orders_judgments.there_are_any = True
+    orders_judgments_re_parties_yes = True
+    orders_judgments_re_parties_no = False
 
   update_orders_judgments = True
 ---


### PR DESCRIPTION
- Fixed #239
- Added additional logic to blocks that update pending legal cases and orders/judgments when these are edited via the review screen.
- Depending on whether there are or aren't pending legal actions, the block now also sets the variables `pending_actions_between_parties_no` and `pending_actions_between_parties_yes` accordingly. These variables set the checkboxes in the PDF template. They are also part of the conditions that trigger the attachment docx file, which contains the list of pending actions.
- The same as above was implemented for the block dealing with orders and judgments.