### PR TITLE
Added code block to reassess petitioner_and_respondent_living_together

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1027,6 +1027,19 @@ code: |
 
   check_minimum_incident_number = True
 ---
+code: |
+  if defined('petitioner_and_respondent_living_together'):
+    if users[0].address.address == other_parties[0].address.address and \
+    users[0].address.unit == other_parties[0].address.unit and \
+    users[0].address.city == other_parties[0].address.city and \
+    users[0].address.state == other_parties[0].address.state and \
+    users[0].address.zip == other_parties[0].address.zip:
+      petitioner_and_respondent_living_together = True
+    else:
+      petitioner_and_respondent_living_together = False
+
+  check_parties_living_together = True
+---
 #################### Overridden AL Questions Start #####################
 ---
 id: your name

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -16,7 +16,10 @@ review:
       % endif
   - raw html: |
       ${ start_accordion('<h2 class="h5">Petitioner (you)</h2>', showing=True) }
-  - Edit: users.revisit
+  - Edit: 
+      - users.revisit
+      - recompute:
+        - check_parties_living_together
     button: |-
       % for item in users:
         **${ item }**
@@ -77,7 +80,10 @@ review:
   - raw html: |
       ${ next_accordion('<h2 class="h5">Respondent</h2>') }
     show if: respondent_lives_in_michigan or not respondent_lives_in_michigan
-  - Edit: other_parties.revisit
+  - Edit: 
+      - other_parties.revisit
+      - recompute:
+        - check_parties_living_together
     button: |-
       % for item in other_parties:
         **${ item }**


### PR DESCRIPTION
- Fixed #238 
- Added block `check_parties_living_together`. Whenever petitioner or respondent address changed via review screen, the block compares each person's address elements against each other. If all match, `petitioner_and_respondent_living_together` is set to True. Otherwise, it's set to False.