### PR TITLE
Removed ability to edit incapacitated adult status + other edits related to Next Friend

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -983,11 +983,11 @@ code: |
   set_parties_same_gender = True
 ---
 code: |
-  if not is_incapacitated_adult:
-    next_friends.clear()
-    next_friends.there_are_any = False
-  else:
+  if is_incapacitated_adult:
     next_friends.there_are_any = True
+  elif petitioner_is_minor:
+    if not petitioner_is_emancipated_minor:
+      next_friends.there_are_any = True
 
   reset_next_friend = True
 ---

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -61,21 +61,26 @@ review:
       **Does the Petitioner live in Michigan?**
 
       ${ word(yesno(petitioner_lives_in_michigan)) }
-  - Edit:
-      - is_incapacitated_adult
+  - raw html: |
+      ${ next_accordion('<h2 class="h5">Next Friend & Incapacitated Adult Status</h2>') }
+    show if: is_incapacitated_adult or next_friends.there_are_any
+  - note: |
+      You told us that you are an **incapacitated adult**. 
+      
+      If you need to change this, please use the **Undo** button or start over from the beginning.
+    show if: is_incapacitated_adult
+  - Edit: 
+      - next_friends.revisit
       - recompute:
-          - reset_next_friend
+        - reset_next_friend
     button: |-
-      **Is the Peititioner an incapacitated adult using a next friend to complete this interview?**
-
-      ${ word(yesno(is_incapacitated_adult)) }
-  - Edit: next_friends.revisit
-    button: |-
-      **Next Friend**
-
+      % if len(next_friends.complete_elements()) > 0:
       % for item in next_friends:
-        ${ item }
+      **Your Next Friend:**  ${ item }
       % endfor
+      % else:
+      *You have not named anyone as your Next Friend yet.*
+      % endif
     show if: next_friends.there_are_any
   - raw html: |
       ${ next_accordion('<h2 class="h5">Respondent</h2>') }
@@ -808,6 +813,15 @@ edit:
   - name.first
   - address.address
   - birthdate
+confirm: True
+---
+table: next_friends.table
+rows: next_friends
+columns:
+  - Name: |
+      row_item.name_full()
+edit:
+  - name.first
 confirm: True
 ---
 table: other_parties.table

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -65,7 +65,7 @@ review:
       ${ next_accordion('<h2 class="h5">Next Friend & Incapacitated Adult Status</h2>') }
     show if: is_incapacitated_adult or next_friends.there_are_any
   - note: |
-      You told us that you are an **incapacitated adult**. 
+      The person who needs a PPO is an **incapacitated adult**.
       
       If you need to change this, please use the **Undo** button or start over from the beginning.
     show if: is_incapacitated_adult
@@ -76,7 +76,7 @@ review:
     button: |-
       % if len(next_friends.complete_elements()) > 0:
       % for item in next_friends:
-      **Your Next Friend:**  ${ item }
+      **Next Friend:**  ${ item }
       % endfor
       % else:
       *You have not named anyone as your Next Friend yet.*


### PR DESCRIPTION
- Fixed #224
- Created new Accordion for "Next Friend and Incapacitated Adult Status. Contains Next Friend block, plus note on how to edit incapacitated adult status when applicable.
- Edited next_friends.table so that interview won't automatically try to ask for a new Next Friend's address.
- Edited `reset_next_friend` block. The block will now be recomputed each time the next_friends review block is used. If the user has deleted their Next Friend entirely, the block sets `next_friends.there_are_any` to True, to make sure a new next friend is collected as soon as the user exits the review screen. Since the same dynamic also applies to Next Friends of minors, I implemented similar logic in the block to handle situations where the user is a minor.

@ekressmiller - Regarding my last note about the `reset_next_friend` block: I was on the fence about whether we'd want to also repeat the `next_friend_agrees_to_role` question whenever a minor user deletes their Next Friend and enters an entirely new one. I left it out for now, but let me know if you think it's worth figuring out that logic before this PR gets merged.