### PR TITLE
Added petitioner_respondent_relationship review block + other related improvements

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -449,26 +449,35 @@ code: |
   check_if_respondent_minor = True
 ---
 code: |
-  if married_choice:
-    if petitioner_respondent_relationship['married']:
-      petitioner_respondent_married = True
+  if married_choice and petitioner_respondent_relationship['married']:
+    petitioner_respondent_married = True
+  else:
+    petitioner_respondent_married = False
 
-  if was_married_choice:
-    if petitioner_respondent_relationship['was_married']:
-      petitioner_respondent_prev_married = True
+  if was_married_choice and petitioner_respondent_relationship['was_married']:
+    petitioner_respondent_prev_married = True
+  else:
+   petitioner_respondent_prev_married = False
 
   if petitioner_respondent_relationship['have_child']:
     petitioner_respondent_have_child = True
-
+  else:
+    petitioner_respondent_have_child = False
+  
   if petitioner_respondent_relationship['dating']:
     petitioner_respondent_dating = True
+  else:
+    petitioner_respondent_dating = False
 
   if petitioner_respondent_relationship['live_together']:
     petitioner_respondent_share_household = True
+  else:
+    petitioner_respondent_share_household = False
 
-  if parent_choice:
-    if petitioner_respondent_relationship['parent']:
-      petitioner_respondent_share_household = True
+  if parent_choice and petitioner_respondent_relationship['parent']:
+    petitioner_respondent_share_household = True
+  else:
+    petitioner_respondent_share_household = False
 
   set_petitioner_respondent_relationship = True
 ---

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -785,6 +785,19 @@ code: |
 
   reset_signature_date = True
 ---
+code: |
+  if (ppo_type == "nondomestic" and (county_choice == "Wayne" or county_choice == "Oakland")) or \
+  (ppo_type == "nondomestic_sexual_assault" and county_choice == "Oakland") or \
+  (ppo_type == "domestic" and (county_choice == "Wayne" or county_choice == "Oakland")):
+    if defined('relationship_to_respondent_exp'):
+      if any(petitioner_respondent_relationship.get(key) for key in ['married', 'was_married', 'have_child', 'dating']):
+        undefine('relationship_to_respondent_exp')
+    else:
+      if all(not petitioner_respondent_relationship.get(key) for key in ['married', 'was_married', 'have_child', 'dating']):
+        relationship_to_respondent_exp
+  
+  reset_relationship_description = True
+---
 #################### Other Code Blocks End #####################
 ---
 # NOTE: for users and other_parties

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -463,18 +463,13 @@ code: |
     petitioner_respondent_have_child = True
   else:
     petitioner_respondent_have_child = False
-  
+
   if petitioner_respondent_relationship['dating']:
     petitioner_respondent_dating = True
   else:
     petitioner_respondent_dating = False
 
-  if petitioner_respondent_relationship['live_together']:
-    petitioner_respondent_share_household = True
-  else:
-    petitioner_respondent_share_household = False
-
-  if parent_choice and petitioner_respondent_relationship['parent']:
+  if petitioner_respondent_relationship['live_together'] or (parent_choice and petitioner_respondent_relationship['parent']):
     petitioner_respondent_share_household = True
   else:
     petitioner_respondent_share_household = False
@@ -2115,6 +2110,24 @@ fields:
     datatype: checkboxes
     code: |
       relationship_choices
+under: |
+  ${ collapse_template(what_if_no_domestic_relationship) }
+validation code: |
+  if petitioner_respondent_relationship.all_false():
+    validation_error("You cannot use this tool to prepare a domestic PPO petition unless you have one of these relationships with the respondent.", field='petitioner_respondent_relationship')
+---
+template: what_if_no_domestic_relationship
+subject: |
+  What if none of these options apply?
+content: |
+  If you don't have a domestic relationship with the Respondent, you cannot use this tool to prepare a Petition for a **domestic relationship** PPO. 
+  
+  You can go back or start over and chooose a different PPO type if 
+  
+  * someone is stalking or harassing you, or 
+  * someone has sexually assaulted you. 
+  
+  Read the article [Overview of Personal Protection Orders ](https://michiganlegalhelp.org/resources/personal-safety/overview-of-personal-protection-orders) to learn about different kinds of PPOs.
 ---
 id: relationship to respondent kickout
 question: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -144,6 +144,7 @@ review:
       - petitioner_respondent_relationship
       - recompute:
         - reset_relationship_description
+        - set_petitioner_respondent_relationship
     button: |-
       **Your Relationship to the Respondent:**
       % if petitioner_respondent_relationship.all_false():

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -147,11 +147,11 @@ review:
         - set_petitioner_respondent_relationship
     button: |-
       **Your Relationship to the Respondent:**
-      % if petitioner_respondent_relationship['married']:
+      % if married_choice and petitioner_respondent_relationship['married']:
 
       * You are currently married.
       % endif
-      % if petitioner_respondent_relationship['was_married']:
+      % if was_married_choice and petitioner_respondent_relationship['was_married']:
 
       * You were previously married.
       % endif
@@ -167,7 +167,7 @@ review:
 
       * You live or used to live together.
       % endif
-      % if petitioner_respondent_relationship['parent']:
+      % if parent_choice and petitioner_respondent_relationship['parent']:
       
       * They are your parent and you live, or used to live, together.
       % endif

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -147,10 +147,6 @@ review:
         - set_petitioner_respondent_relationship
     button: |-
       **Your Relationship to the Respondent:**
-      % if petitioner_respondent_relationship.all_false():
-
-      *You chose "None of the above" from the list provided.*
-      % else:
       % if petitioner_respondent_relationship['married']:
 
       * You are currently married.
@@ -174,7 +170,6 @@ review:
       % if petitioner_respondent_relationship['parent']:
       
       * They are your parent and you live, or used to live, together.
-      % endif
       % endif
   - Edit: relationship_to_respondent_exp
     button: |-

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -87,16 +87,7 @@ review:
     button: |-
       % for item in other_parties:
         **${ item }**
-        % if (ppo_type == "nondomestic" and (county_choice == "Wayne" or county_choice == "Oakland")) or \
-        (ppo_type == "nondomestic_sexual_assault" and county_choice == "Oakland") or \
-        (ppo_type == "domestic" and (county_choice == "Wayne" or county_choice == "Oakland") and \
-        all(not petitioner_respondent_relationship.get(key) for key in ['married', 'was_married', 'have_child', 'dating'])):
-        % if relationship_to_respondent_exp:
 
-        Relationship to You: ${ relationship_to_respondent_exp }
-        % endif
-        % endif
-        
         % if knows_respondents_birthdate:
         Age: ${ item.age_in_years() }
         % else:
@@ -149,6 +140,50 @@ review:
         
         ${ word("") if item.no_phone_number else item.phone_numbers() }
       % endfor
+  - Edit: 
+      - petitioner_respondent_relationship
+      - recompute:
+        - reset_relationship_description
+    button: |-
+      **Your Relationship to the Respondent:**
+      % if petitioner_respondent_relationship.all_false():
+
+      *You chose "None of the above" from the list provided.*
+      % else:
+      % if petitioner_respondent_relationship['married']:
+
+      * You are currently married.
+      % endif
+      % if petitioner_respondent_relationship['was_married']:
+
+      * You were previously married.
+      % endif
+      % if petitioner_respondent_relationship['have_child']:
+
+      * You have children together.
+      % endif
+      % if petitioner_respondent_relationship['dating']:
+
+      * You dated or are dating.
+      % endif
+      % if petitioner_respondent_relationship['live_together']:
+
+      * You live or used to live together.
+      % endif
+      % if petitioner_respondent_relationship['parent']:
+      
+      * They are your parent and you live, or used to live, together.
+      % endif
+      % endif
+  - Edit: relationship_to_respondent_exp
+    button: |-
+      **Describe Your Relationship to the Respondent:**
+
+      % if relationship_to_respondent_exp:
+      ${ relationship_to_respondent_exp }
+      % else:
+      *You have not entered a description of your relationship yet.*
+      % endif
   - Edit: other_party_alias.there_are_any
     button: |-
       **Does the Respondent have any aliases?**


### PR DESCRIPTION
- Fixed #248 
- Added individual block to display petitioner_respondent_relationship choices outside of main petitioner review block.
- Moved relationship_to_respondent_exp into its own review block.
- Added logic to recompute relationship_to_respondent_exp, depending on how the user edits their choices for petitioner_respondent_relationship. Provided that the ppo_type and county_choice conditions are met, the new relationship choices will either undefine relationship_to_respondent_exp or trigger a fresh question screen for it. 