### PR TITLE
Moved next friend and incapacitated adult note to petitioner block

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -19,6 +19,11 @@ review:
   - raw html: |
       ${ start_accordion('<h2 class="h5">Petitioner (you)</h2>') }
     show if: is_incapacitated_adult or not is_incapacitated_adult
+  - note: |
+      The person who needs a PPO is an **incapacitated adult**.
+      
+      If you need to change this, please use the **Undo** button or start over from the beginning.
+    show if: is_incapacitated_adult
   - Edit: 
       - users.revisit
       - recompute:
@@ -65,14 +70,6 @@ review:
       **Does the Petitioner live in Michigan?**
 
       ${ word(yesno(petitioner_lives_in_michigan)) }
-  - raw html: |
-      ${ next_accordion('<h2 class="h5">Next Friend & Incapacitated Adult Status</h2>') }
-    show if: is_incapacitated_adult or next_friends.there_are_any
-  - note: |
-      The person who needs a PPO is an **incapacitated adult**.
-      
-      If you need to change this, please use the **Undo** button or start over from the beginning.
-    show if: is_incapacitated_adult
   - Edit: 
       - next_friends.revisit
       - recompute:


### PR DESCRIPTION
- Fixed #256 
- Moved Next Friend review block to the bottom of the Petitioner accordion
- Movied note on incapacitated adult status to the top of the Petitioner accordion; given the color difference with the regular review blocks, I thought it would fit the visual pattern better and lessen the chance of users skipping over the information when scanning between accordions. See image below.

<img width="861" alt="Screenshot 2024-12-18 at 2 16 07 AM" src="https://github.com/user-attachments/assets/51958601-b014-42e2-bd5a-2546cf516170" />