### PR TITLE
SA Petition Review Screen work

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -5346,6 +5346,7 @@ attachments:
     - wants_no_children_property_removal_interference: ${ wants_no_children_property_removal_interference }
     - wants_no_work_education_interference: ${ wants_no_work_education_interference }
     - wants_no_firearm_purchase_or_possession: ${ wants_no_firearm_purchase_or_possession }
+    - wants_no_message_posting: ${ wants_no_message_posting }
     - wants_other_request: ${ wants_other_request }
     - other_request_see_attached: |
         % if wants_other_request:
@@ -5463,6 +5464,7 @@ attachments:
     - wants_no_children_property_removal_interference: ${ wants_no_children_property_removal_interference }
     - wants_no_work_education_interference: ${ wants_no_work_education_interference }
     - wants_no_firearm_purchase_or_possession: ${ wants_no_firearm_purchase_or_possession }
+    - wants_no_message_posting: ${ wants_no_message_posting }
     - wants_other_request: ${ wants_other_request }
     - other_request_see_attached: |
         % if wants_other_request:

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -535,11 +535,25 @@ code: |
 code: |
   if len(orders_judgments.complete_elements()) > 0:
     orders_judgments_re_parties_yes = True
+    orders_judgments_re_parties_no = False
   else:
     orders_judgments_re_parties_yes = False
     orders_judgments_re_parties_no = True
 
   orders_judgments_asked = True
+# ---
+# code: |
+#   if not orders_judgments.there_are_any:
+#     orders_judgments.clear()
+#     orders_judgments.there_are_any = False
+#     orders_judgments_re_parties_yes = False
+#     orders_judgments_re_parties_no = True
+#   else:
+#     orders_judgments.there_are_any = True
+#     orders_judgments_re_parties_yes = True
+#     orders_judgments_re_parties_no = False
+# 
+#   update_orders_judgments = True
 ---
 code: |
   if orders_judgments[i].court_name and orders_judgments[i].court_county:
@@ -1048,19 +1062,6 @@ code: |
     pending_actions_between_parties_no = False
 
   update_pending_actions = True
----
-code: |
-  if not orders_judgments.there_are_any:
-    orders_judgments.clear()
-    orders_judgments.there_are_any = False
-    orders_judgments_re_parties_yes = False
-    orders_judgments_re_parties_no = True
-  else:
-    orders_judgments.there_are_any = True
-    orders_judgments_re_parties_yes = True
-    orders_judgments_re_parties_no = False
-
-  update_orders_judgments = True
 ---
 code: |
   if ppo_type == "domestic":
@@ -2807,6 +2808,18 @@ fields:
   - Enter the case number: orders_judgments[i].docket_number
     required: False
 ---
+id: orders_judgments docket number sexual assault conviction
+if: ppo_type == "nondomestic_sexual_assault" and respondent_sexual_assault_conviction == True
+sets:
+  - orders_judgments[0].docket_number
+question: |
+  Sexual assault conviction case number
+subquestion: |
+  Leave blank if unknown.
+fields:
+  - Enter the case number for the sexual assault conviction: orders_judgments[0].docket_number
+    required: False
+---
 id: orders_judgments court and county
 question: |
   Enter the name of the court and county where the case was filed, if known
@@ -2816,6 +2829,22 @@ fields:
   - Court county: orders_judgments[i].court_county
     required: False
   - Court state: orders_judgments[i].court_state
+    required: False
+    code: |
+      states_list()
+---
+id: orders_judgments court and county sexual assault conviction
+if: ppo_type == "nondomestic_sexual_assault" and respondent_sexual_assault_conviction == True
+question: |
+  Court and county of sexual assault conviction
+subquestion: |
+  Enter the name of the court and county where the sexual assault case was filed, if known.
+fields:
+  - Court name: orders_judgments[0].court_name
+    required: False
+  - Court county: orders_judgments[0].court_county
+    required: False
+  - Court state: orders_judgments[0].court_state
     required: False
     code: |
       states_list()
@@ -2836,6 +2865,19 @@ subquestion: |
   % endif
 fields:
   - Are there any more court orders or judgments entered between you and ${ other_parties[0].name }?: orders_judgments.there_is_another
+    datatype: yesnoradio
+    label above field: True
+---
+id: orders_judgments there_is_another yes sexual assault conviction
+if: ppo_type == "nondomestic_sexual_assault" and respondent_sexual_assault_conviction == True
+question: |
+  Other convictions, court orders, or judgments
+subquestion: |
+  % if len(orders_judgments.complete_elements()) > 0:
+  ${ collapse_template(orders_judgments_list_template) }
+  % endif
+fields:
+  - Are there any more convictions, court orders, or judgments entered between you and ${ other_parties[0].name }?: orders_judgments.there_is_another
     datatype: yesnoradio
     label above field: True
 ---
@@ -2936,57 +2978,6 @@ fields:
 validation code: |
   if not respondent_sexual_assault_conviction and not fears_future_sexual_assault:
     validation_error("You can't continue unless one of these things is true.")
-# ---
-# id: respondent sexual assault conviction, yes orders listed
-# if: orders_judgments_re_parties_yes == True
-# question: |
-#   Sexual assault convictions
-# fields:
-#   - Was ${ other_parties[0].name } convicted of sexual assault against you?: respondent_sexual_assault_conviction
-#     datatype: yesnoradio
-#   - Did you list the sexual assault conviction when asked about orders or judgments between you and ${ other_parties[0].name }?: orders_judgments_include_sa_conviction
-#     datatype: yesnoradio
-#     label above field: True
-#     show if:
-#       variable: respondent_sexual_assault_conviction
-#       is: True
-#   - note: |
-#       ${ collapse_template(orders_judgments_list_template) }
-#     show if:
-#       variable: respondent_sexual_assault_conviction
-#       is: True
-#   - note: |
-#       Tap **Continue** and enter information about this conviction.
-#     show if:
-#       variable: orders_judgments_include_sa_conviction
-#       is: False
-#   - Do you fear that you could be sexually assaulted because ${ other_parties[0].name } has sexually assaulted you or threatened you with sexual assault?: fears_future_sexual_assault
-#     datatype: yesnoradio
-#     show if: 
-#       variable: respondent_sexual_assault_conviction
-#       is: False
-#   - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }: potential_sexual_assault_exp
-#     input type: area
-#     show if:
-#       variable: fears_future_sexual_assault
-#       is: True
-#   - note: |
-#       ${ collapse_template(fears_future_sexual_assault_explained) }
-#     show if:
-#       variable: fears_future_sexual_assault
-#       is: True
-#   - note: |
-#         We're sorry, but you may not use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
-# 
-#         There are different forms available if you need protection from someone who is stalking or harassing you, or from someone with whom you have or had a domestic relationship. Return to the Michigan Legal Help website and read [Overview of Personal Protection Orders](https://michiganlegalhelp.org/resources/personal-safety/overview-of-personal-protection-orders) to learn if there is a different kind of protection order for you.
-# 
-#         If you made a mistake, tap the **${ MLH_back_button_label }** button to go back and change your answer. Otherwise, you can return to [Michigan Legal Help](https://michiganlegalhelp.org) for other legal information or resources.
-#     show if:
-#       variable: fears_future_sexual_assault
-#       is: False
-# validation code: |
-#   if not respondent_sexual_assault_conviction and not fears_future_sexual_assault:
-#     validation_error("You can't continue unless one of these things is true.")
 ---
 template: fears_future_sexual_assault_explained
 subject: |
@@ -2996,29 +2987,55 @@ content: |
 
   If you have any documents you want to show the judge, such as police reports, medical records, photos, copies of letters, texts, or email messages, you can attach copies to your petition. However, this is not necessary. The judge shouldn't deny a petition just because you don't have any documents to attach.
 ---
+undefine:
+  - sexual_assault_conviction_required
 code: |
-  if respondent_sexual_assault_conviction == True:
-    if len(orders_judgments.complete_elements()) == 0:
-      reset_SA_conviction_gather_first
-    elif orders_judgments_include_sa_conviction == False:
-      reset_SA_conviction_gather_subsequent
+  reset_SA_convictions_check = True
+---
+id: sexual assault conviction required warning
+continue button field: sexual_assault_conviction_required
+question: |
+  You must list ${ other_parties[0].name }'s conviction for sexual assault
+subquestion: |
+  You said ${ other_parties[0].name } was convicted of sexual assault against you. You **must include this conviction** in your list of Court Orders and Judgments. 
+
+  % if len(orders_judgments.complete_elements()) > 0:
+  ${ collapse_template(orders_judgments_list_template) }
   
+  If you need to add a conviction:
+  
+  * tap **${MLH_continue_button_label}** below, and 
+  * tap **Court Orders and Judgments** on the next screen.
+  % endif
+---
+code: |
+  if ppo_type == "nondomestic_sexual_assault" and respondent_sexual_assault_conviction:
+    if len(orders_judgments.complete_elements()) < 1:
+      minimum_convictions_explainer
+      orders_judgments.gather(minimum=1)
+
+  check_minimum_convictions_number = True
+---
+code: |
+  if ppo_type == "nondomestic_sexual_assault" and respondent_sexual_assault_conviction:
+    if len(orders_judgments.complete_elements()) >= 1:
+      sexual_assault_conviction_required
+
   SA_convictions_check = True
 ---
-only sets: reset_SA_conviction_gather_first
 undefine:
-  - orders_judgments.gathered
+  - minimum_convictions_explainer
 code: |
-  orders_judgments.target_number = 1
-  reset_SA_conviction_gather_first = True
+  reset_minimum_convictions_check = True
 ---
-only sets: reset_SA_conviction_gather_subsequent
+id: minimum convictions
 undefine:
   - orders_judgments.gathered
-code: |
-  orders_judgments.there_is_another = True
-  
-  reset_SA_conviction_gather_subsequent = True
+question: |
+  You need to add a conviction
+subquestion: |
+  You said ${ other_parties[0].name } was convicted of sexual assault against you. You **must include this conviction** in your list of Court Orders and Judgments. 
+continue button field: minimum_convictions_explainer
 ---
 template: stalking_harassing_explained
 subject: |
@@ -4035,7 +4052,7 @@ subquestion: |
 
   **Important:** Read the **Instructions** document for what to do next. 
 
-  To get a copy of your forms or instructions, tap **Continue**. 
+  To get a copy of your forms or instructions, tap **${MLH_continue_button_label}**. 
 
   Now that you emailed your forms to the clerk, changes made to answers in this program **will not** appear on the court's copy of your forms.
 under: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -541,19 +541,6 @@ code: |
     orders_judgments_re_parties_no = True
 
   orders_judgments_asked = True
-# ---
-# code: |
-#   if not orders_judgments.there_are_any:
-#     orders_judgments.clear()
-#     orders_judgments.there_are_any = False
-#     orders_judgments_re_parties_yes = False
-#     orders_judgments_re_parties_no = True
-#   else:
-#     orders_judgments.there_are_any = True
-#     orders_judgments_re_parties_yes = True
-#     orders_judgments_re_parties_no = False
-# 
-#   update_orders_judgments = True
 ---
 code: |
   if orders_judgments[i].court_name and orders_judgments[i].court_county:
@@ -2940,7 +2927,6 @@ subquestion: |
 continue button field: sexual_assault_intro
 ---
 id: respondent sexual assault conviction, no orders listed yet
-# if: orders_judgments_re_parties_yes == False
 question: |
   Sexual assault convictions
 fields:

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -226,12 +226,13 @@ code: |
           respondent_other_children.target_number
           respondent_other_children.gather()
 
-  if pending_actions.there_are_any:
-    pending_actions.gather()
-  pending_actions_asked
-  if orders_judgments.there_are_any:
-    orders_judgments.gather()
-  orders_judgments_asked
+  if ppo_type != "nondomestic_sexual_assault":
+    if pending_actions.there_are_any:
+      pending_actions.gather()
+    pending_actions_asked
+    if orders_judgments.there_are_any:
+      orders_judgments.gather()
+    orders_judgments_asked
 
   nav.set_section("review_abuse_history_info")
   if ppo_type == "domestic":
@@ -248,12 +249,15 @@ code: |
 
   if ppo_type == "nondomestic_sexual_assault":
     sexual_assault_intro
+    if respondent_sexual_assault_conviction:
+      orders_judgments.gather(minimum=1)
+    elif orders_judgments.there_are_any:
+      orders_judgments.gather()
+    orders_judgments_asked
 
-    if not respondent_sexual_assault_conviction:
-      if fears_future_sexual_assault:
-        potential_sexual_assault_exp
-      else:
-        no_past_or_potential_sexual_assault_kickout
+    if pending_actions.there_are_any:
+      pending_actions.gather()
+    pending_actions_asked
 
   if ppo_type == "nondomestic":
     incidents.gather(minimum=2)
@@ -2160,7 +2164,7 @@ question: |
 subquestion: |
   We're sorry, but if you don't have a domestic relationship with the Respondent, you cannot use this tool to prepare a Petition for a domestic relationship *Personal Protection Order*.
 
-  There are different forms available if you need protection from someone who is stalking or harassing you, or from someone who has sexually assaulted you. Read the article [Overview of Personal Protection Orders](https://michiganlegalhelp.org/self-help-tools/personal-safety/overview-personal-protection-orders) to learn if there is a different kind of protection order for you.
+  There are different forms available if you need protection from someone who is stalking or harassing you, or from someone who has sexually assaulted you. Read the article [Overview of Personal Protection Orders](https://michiganlegalhelp.org/resources/personal-safety/overview-of-personal-protection-orders) to learn if there is a different kind of protection order for you.
 
   If you made a mistake, tap the **${ MLH_back_button_label }** button to go back and change your answer.
 ---
@@ -2894,65 +2898,95 @@ subquestion: |
 continue button field: sexual_assault_intro
 ---
 id: respondent sexual assault conviction, no orders listed yet
-if: orders_judgments_re_parties_yes == False
+# if: orders_judgments_re_parties_yes == False
 question: |
   Sexual assault convictions
 fields:
   - Was ${ other_parties[0].name } convicted of sexual assault against you?: respondent_sexual_assault_conviction
     datatype: yesnoradio
   - note: |
-      Tap **${ MLH_back_button_label }** twice to go back to the "Court orders and judgments" screen and add information about this conviction.
+      Make sure you add information about this conviction.
     show if:
       variable: respondent_sexual_assault_conviction
       is: True
-validation code: |
-  if respondent_sexual_assault_conviction:
-    validation_error("Tap Undo twice to go back to the Court orders and judgments screen and add information about this conviction.")
----
-id: respondent sexual assault conviction, yes orders listed
-if: orders_judgments_re_parties_yes == True
-question: |
-  Sexual assault convictions
-fields:
-  - Was ${ other_parties[0].name } convicted of sexual assault against you?: respondent_sexual_assault_conviction
-    datatype: yesnoradio
-  - Did you list the sexual assault conviction when asked about orders or judgments between you and ${ other_parties[0].name }?: orders_judgments_include_sa_conviction
-    datatype: yesnoradio
-    label above field: True
-    show if:
-      variable: respondent_sexual_assault_conviction
-      is: True
-  - note: |
-      ${ collapse_template(orders_judgments_list_template) }
-    show if:
-      variable: respondent_sexual_assault_conviction
-      is: True
-  - note: |
-      Tap **${ MLH_back_button_label }** twice to go back to the "Other court orders and judgments" screen and add information about this conviction.
-    show if:
-      variable: orders_judgments_include_sa_conviction
-      is: False
-validation code: |
-  if respondent_sexual_assault_conviction and not orders_judgments_include_sa_conviction:
-    validation_error("Tap Undo twice to go back to the Other court orders and judgments screen and add information about this conviction.")
----
-id: fear of future sexual assault
-question: |
-  Fear of future sexual assault
-fields:
   - Do you fear that you could be sexually assaulted because ${ other_parties[0].name } has sexually assaulted you or threatened you with sexual assault?: fears_future_sexual_assault
     datatype: yesnoradio
-    label above field: True
----
-id: potential sexual assault explained
-question: |
-  Fear of future sexual assault explanation
-subquestion: |
-  ${ collapse_template(fears_future_sexual_assault_explained) }
-fields:
+    show if: 
+      variable: respondent_sexual_assault_conviction
+      is: False
   - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }: potential_sexual_assault_exp
     input type: area
-    label above field: True
+    show if:
+      variable: fears_future_sexual_assault
+      is: True
+  - note: |
+      ${ collapse_template(fears_future_sexual_assault_explained) }
+    show if:
+      variable: fears_future_sexual_assault
+      is: True
+  - note: |
+        We're sorry, but you may not use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
+
+        There are different forms available if you need protection from someone who is stalking or harassing you, or from someone with whom you have or had a domestic relationship. Return to the Michigan Legal Help website and read [Overview of Personal Protection Orders](https://michiganlegalhelp.org/resources/personal-safety/overview-of-personal-protection-orders) to learn if there is a different kind of protection order for you.
+
+        If you made a mistake, tap the **${ MLH_back_button_label }** button to go back and change your answer. Otherwise, you can return to [Michigan Legal Help](https://michiganlegalhelp.org) for other legal information or resources.
+    show if:
+      variable: fears_future_sexual_assault
+      is: False
+validation code: |
+  if not respondent_sexual_assault_conviction and not fears_future_sexual_assault:
+    validation_error("You can't continue unless one of these things is true.")
+# ---
+# id: respondent sexual assault conviction, yes orders listed
+# if: orders_judgments_re_parties_yes == True
+# question: |
+#   Sexual assault convictions
+# fields:
+#   - Was ${ other_parties[0].name } convicted of sexual assault against you?: respondent_sexual_assault_conviction
+#     datatype: yesnoradio
+#   - Did you list the sexual assault conviction when asked about orders or judgments between you and ${ other_parties[0].name }?: orders_judgments_include_sa_conviction
+#     datatype: yesnoradio
+#     label above field: True
+#     show if:
+#       variable: respondent_sexual_assault_conviction
+#       is: True
+#   - note: |
+#       ${ collapse_template(orders_judgments_list_template) }
+#     show if:
+#       variable: respondent_sexual_assault_conviction
+#       is: True
+#   - note: |
+#       Tap **Continue** and enter information about this conviction.
+#     show if:
+#       variable: orders_judgments_include_sa_conviction
+#       is: False
+#   - Do you fear that you could be sexually assaulted because ${ other_parties[0].name } has sexually assaulted you or threatened you with sexual assault?: fears_future_sexual_assault
+#     datatype: yesnoradio
+#     show if: 
+#       variable: respondent_sexual_assault_conviction
+#       is: False
+#   - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }: potential_sexual_assault_exp
+#     input type: area
+#     show if:
+#       variable: fears_future_sexual_assault
+#       is: True
+#   - note: |
+#       ${ collapse_template(fears_future_sexual_assault_explained) }
+#     show if:
+#       variable: fears_future_sexual_assault
+#       is: True
+#   - note: |
+#         We're sorry, but you may not use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
+# 
+#         There are different forms available if you need protection from someone who is stalking or harassing you, or from someone with whom you have or had a domestic relationship. Return to the Michigan Legal Help website and read [Overview of Personal Protection Orders](https://michiganlegalhelp.org/resources/personal-safety/overview-of-personal-protection-orders) to learn if there is a different kind of protection order for you.
+# 
+#         If you made a mistake, tap the **${ MLH_back_button_label }** button to go back and change your answer. Otherwise, you can return to [Michigan Legal Help](https://michiganlegalhelp.org) for other legal information or resources.
+#     show if:
+#       variable: fears_future_sexual_assault
+#       is: False
+# validation code: |
+#   if not respondent_sexual_assault_conviction and not fears_future_sexual_assault:
+#     validation_error("You can't continue unless one of these things is true.")
 ---
 template: fears_future_sexual_assault_explained
 subject: |
@@ -2962,16 +2996,29 @@ content: |
 
   If you have any documents you want to show the judge, such as police reports, medical records, photos, copies of letters, texts, or email messages, you can attach copies to your petition. However, this is not necessary. The judge shouldn't deny a petition just because you don't have any documents to attach.
 ---
-id: no past or potential sexual assault kickout
-event: no_past_or_potential_sexual_assault_kickout
-question: |
-  You cannot continue using this tool
-subquestion: |
-  We're sorry, but you may not use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
-
-  There are different forms available if you need protection from someone who is stalking or harassing you, or from someone with whom you have or had a domestic relationship. Return to the Michigan Legal Help website and read [Overview of Personal Protection Orders](https://michiganlegalhelp.org/self-help-tools/personal-safety/overview-personal-protection-orders) to learn if there is a different kind of protection order for you.
-
-  If you made a mistake, tap the **${ MLH_back_button_label }** button to go back and change your answer. Otherwise, you can return to [Michigan Legal Help](https://michiganlegalhelp.org) for other legal information or resources.
+code: |
+  if respondent_sexual_assault_conviction == True:
+    if len(orders_judgments.complete_elements()) == 0:
+      reset_SA_conviction_gather_first
+    elif orders_judgments_include_sa_conviction == False:
+      reset_SA_conviction_gather_subsequent
+  
+  SA_convictions_check = True
+---
+only sets: reset_SA_conviction_gather_first
+undefine:
+  - orders_judgments.gathered
+code: |
+  orders_judgments.target_number = 1
+  reset_SA_conviction_gather_first = True
+---
+only sets: reset_SA_conviction_gather_subsequent
+undefine:
+  - orders_judgments.gathered
+code: |
+  orders_judgments.there_is_another = True
+  
+  reset_SA_conviction_gather_subsequent = True
 ---
 template: stalking_harassing_explained
 subject: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -408,46 +408,20 @@ review:
       % endif
     show if: pending_actions.there_are_any
   - raw html: |
-      ${ next_accordion('<h2 class="h5">Court Orders and Judgments</h2>') }
-    show if: defined('orders_judgments.there_are_any')
-  - Edit: 
-      - orders_judgments.there_are_any
-      - recompute:
-        - update_orders_judgments
-    button: |
-      **Are there any pending court orders or judgments regarding you and ${ other_parties[0] }?**
-
-      % if orders_judgments.there_are_any:
-      Yes
-      % elif not orders_judgments.there_are_any:
-      No
-      % endif
-  - Edit:
-      - orders_judgments.revisit
-    button: |
-      % if len(orders_judgments.complete_elements()) > 0:
-      % for item in orders_judgments:
-
-      **Pending Order/Judgment \#${ loop.index+1 }**
-
-      * Docket: ${ item.docket_number }
-      * Court: ${ item.court_name }
-      * County: ${ item.court_county }
-      * State: ${ item.court_state }
-      * Judge: ${ item.judge }
-
-
-      % endfor
-      % else:
-      You have not listed any orders or judgments yet.
-      % endif
-    show if: orders_judgments.there_are_any
-  - raw html: |
       ${ next_accordion('<h2 class="h5">Sexual Assault History</h2>') }
     show if: defined('respondent_sexual_assault_conviction')
-  - Edit: respondent_sexual_assault_conviction
+  - Edit: 
+      - respondent_sexual_assault_conviction
+      - recompute:
+        - reset_SA_convictions_check
+        - SA_convictions_check
+        - reset_minimum_convictions_check
+        - check_minimum_convictions_number
+        - orders_judgments_asked
     button: |
-      **Was ${ other_parties[0] } convicted of sexual assault against you?**  ${ word(yesno(respondent_sexual_assault_conviction)) }
+      **Was ${ other_parties[0] } convicted of sexual assault against you?**  
+      
+      ${ word(yesno(respondent_sexual_assault_conviction)) }
       
       % if not respondent_sexual_assault_conviction:
       **Do you fear that you could be sexually assaulted because ${ other_parties[0] } has either committed or threated sexual assault against you?**
@@ -459,6 +433,59 @@ review:
       ${ potential_sexual_assault_exp }
 
       % endif
+  - raw html: |
+      ${ next_accordion('<h2 class="h5">Court Orders and Judgments</h2>') }
+    show if: defined('orders_judgments.there_are_any')
+#   - Edit: 
+#       - orders_judgments.there_are_any
+#       - recompute:
+#         - orders_judgments_asked
+#     button: |
+#       % if ppo_type == "nondomestic_sexual_assault":
+#       **Are there any convictions, court orders, or judgments regarding you and ${ other_parties[0] }?**
+#       % else:
+#       **Are there any court orders or judgments regarding you and ${ other_parties[0] }?**
+#       % endif
+# 
+#       % if orders_judgments.there_are_any:
+#       Yes
+#       % elif not orders_judgments.there_are_any:
+#       No
+#       % endif
+  - note: |
+      % if ppo_type == "nondomestic_sexual_assault":
+      Convictions, court orders, or judgments regarding you and ${ other_parties[0] }:
+      % else:
+      Court orders or judgments regarding you and ${ other_parties[0] }:
+      % endif
+  - Edit:
+      - orders_judgments.revisit
+      - recompute:
+        - reset_minimum_convictions_check
+        - check_minimum_convictions_number
+        - orders_judgments_asked
+    button: |
+      % if len(orders_judgments.complete_elements()) > 0:
+      % for item in orders_judgments:
+
+      **Order/Judgment \#${ loop.index+1 }**
+
+      * Docket: ${ item.docket_number }
+      * Court: ${ item.court_name }
+      * County: ${ item.court_county }
+      * State: ${ item.court_state }
+      * Judge: ${ item.judge }
+
+
+      % endfor
+      % else:
+      % if ppo_type == "nondomestic_sexual_assault":
+      You have not listed any convictions, orders, or judgments yet.
+      % else:
+      You have not listed any orders or judgments yet.
+      % endif
+      % endif
+    show if: orders_judgments.there_are_any or not orders_judgments.there_are_any
   - raw html: |
       ${ next_accordion('<h2 class="h5">Past Incidents</h2>') }
     show if: len(incidents.complete_elements()) > 0

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -436,22 +436,6 @@ review:
   - raw html: |
       ${ next_accordion('<h2 class="h5">Court Orders and Judgments</h2>') }
     show if: defined('orders_judgments.there_are_any')
-#   - Edit: 
-#       - orders_judgments.there_are_any
-#       - recompute:
-#         - orders_judgments_asked
-#     button: |
-#       % if ppo_type == "nondomestic_sexual_assault":
-#       **Are there any convictions, court orders, or judgments regarding you and ${ other_parties[0] }?**
-#       % else:
-#       **Are there any court orders or judgments regarding you and ${ other_parties[0] }?**
-#       % endif
-# 
-#       % if orders_judgments.there_are_any:
-#       Yes
-#       % elif not orders_judgments.there_are_any:
-#       No
-#       % endif
   - note: |
       % if ppo_type == "nondomestic_sexual_assault":
       Convictions, court orders, or judgments regarding you and ${ other_parties[0] }:

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -408,7 +408,7 @@ review:
       % endif
     show if: pending_actions.there_are_any
   - raw html: |
-      ${ next_accordion('<h2 class="h5">Pending Orders & Judgments</h2>') }
+      ${ next_accordion('<h2 class="h5">Court Orders and Judgments</h2>') }
     show if: defined('orders_judgments.there_are_any')
   - Edit: 
       - orders_judgments.there_are_any

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -447,28 +447,18 @@ review:
     show if: defined('respondent_sexual_assault_conviction')
   - Edit: respondent_sexual_assault_conviction
     button: |
-      **Was ${ other_parties[0] } convicted of sexual assault against you?**
-
-      ${ word(yesno(respondent_sexual_assault_conviction)) }
-  - Edit: orders_judgments_include_sa_conviction
-    button: |
-      **Did you list the case where ${ other_parties[0] } was convicted of sexual assault against you when asked about past orders or judgments?**
-
-      ${ word(yesno(orders_judgments_include_sa_conviction)) }
-    show if: respondent_sexual_assault_conviction
-  - Edit: fears_future_sexual_assault
-    button: |
+      **Was ${ other_parties[0] } convicted of sexual assault against you?**  ${ word(yesno(respondent_sexual_assault_conviction)) }
+      
+      % if not respondent_sexual_assault_conviction:
       **Do you fear that you could be sexually assaulted because ${ other_parties[0] } has either committed or threated sexual assault against you?**
 
       ${ word(yesno(fears_future_sexual_assault)) }
-    show if: not respondent_sexual_assault_conviction
-  - Edit: potential_sexual_assault_exp
-    button: |
+
       **Explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0] }:**
 
       ${ potential_sexual_assault_exp }
 
-    show if: fears_future_sexual_assault
+      % endif
   - raw html: |
       ${ next_accordion('<h2 class="h5">Past Incidents</h2>') }
     show if: len(incidents.complete_elements()) > 0


### PR DESCRIPTION
rework sexual assault basis questions in order to make the review screen logic work, closes #261:
- For SA only, changed order of gathering orders and pending cases so we can force gather the conviction if there is one.
- Set up checks to trigger gather and/or reminder to check to make sure conviction is entered as needed when answers are changed on review screen
- remove orders_judgments.there_are_any from review screen to simplify logic
- make special gather screens for orders_judgments[0] in SA situations where there is a conviction to make it clear what we're asking for
- related wording changes

miscellaneous stuff:
- add harassing electronic message check on petition when selected (was missing)
- fix PPO overview article URL
- fix a few references to continue button
