### PR TITLE
Reworked set_mental_distress_control_options and added recompute in review block

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -693,15 +693,23 @@ code: |
 code: |
   if no_mental_distress_or_control_choices['harming_animal']:
     intentional_mental_distress_includes_animal_harm = True
-    wants_no_intentional_mental_distress_or_control = True
+  else:
+    intentional_mental_distress_includes_animal_harm = False
 
   if no_mental_distress_or_control_choices['removing_animal']:
     intentional_mental_distress_includes_removing_animal = True
-    wants_no_intentional_mental_distress_or_control = True
+  else:
+    intentional_mental_distress_includes_removing_animal = False
 
   if no_mental_distress_or_control_choices['keeping_animal']:
     intentional_mental_distress_includes_retaining_animal = True
+  else:
+    intentional_mental_distress_includes_retaining_animal = False
+  
+  if any(no_mental_distress_or_control_choices.get(key) for key in ['harming_animal', 'removing_animal', 'keeping_animal']):
     wants_no_intentional_mental_distress_or_control = True
+  else:
+    wants_no_intentional_mental_distress_or_control = False
 
   set_mental_distress_control_options = True
 ---

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -720,7 +720,10 @@ review:
       **Do you want the judge to order ${ other_parties[0] } to not have access to information in your child’s records that shows your (or your child’s) home address, phone number, or work address?**
 
       ${ word(yesno(wants_no_access_to_personal_info_records)) }
-  - Edit: no_mental_distress_or_control_choices
+  - Edit: 
+      - no_mental_distress_or_control_choices
+      - recompute:
+        - set_mental_distress_control_options
     button: |-
       **I want the judge to order ${ other_parties[0] } to not intentionally cause me mental distress or try to control me through the following behaviors:**
       % if no_mental_distress_or_control_choices.all_false():


### PR DESCRIPTION
- Fixed #263
- Reworked logic of set_mental_distress_control_options code block
- Added recompute for set_mental_distress_control_options in the no_mental_distress_or_control_choices review block 