### PR TITLE
Chunked info for review blocks and tables

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -911,21 +911,7 @@ edit:
   - phone_number
 confirm: True
 ---
-# table: children.table
-# rows: children
-# columns:
-#   - Name: |
-#       row_item.name_full()
-#   - Birthdate: |
-#       row_item.birthdate
-# edit:
-#   - name.first
-#   - lives_with
-#   - parties_married_when_born
-#   - has_order_in_effect
-# confirm: True
----
-event: |-
+continue button field: |-
   children.revisit
 id: |-
   revisit children
@@ -940,8 +926,6 @@ columns:
       row_item.name if hasattr(row_item, 'name') else ''
   - 'DOB': |-
       row_item.birthdate if hasattr(row_item, 'birthdate') else ''
-  - 'Lives with': |-
-      row_item.lives_with if hasattr(row_item, 'lives_with') else ''
 rows: |-
   children
 table: |-
@@ -951,6 +935,7 @@ edit:
   - lives_with
   - parties_married_when_born
   - has_order_in_effect
+  - complete
 ---
 table: petitioner_other_children.table
 rows: petitioner_other_children

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -110,8 +110,10 @@ review:
     button: |-
       **What is the Respondent's gender?**
       % if other_parties[0].gender == "M":
+
       Male
       % elif other_parties[0].gender == "F":
+
       Female
       % endif
   - Edit: other_parties[0].race
@@ -243,66 +245,75 @@ review:
   - raw html: |
       ${ next_accordion('<h2 class="h5">Children</h2>') }
     show if: (len(children.complete_elements()) > 0) or (len(petitioner_other_children.complete_elements()) > 0) or (len(respondent_other_children.complete_elements()) > 0)
-  - Edit: children.revisit
+  - Edit: 
+      - children.revisit
     button: |-
       % for item in children:
 
         **${ item }**
 
-        DOB: ${ item.birthdate }
+        * DOB: ${ item.birthdate }
         % if item.lives_with:
+        % if item.lives_with == "petitioner":
 
-        Lives with: ${ item.lives_with }
+        * Lives with: Petitioner
+        % elif item.lives_with == "respondent":
+
+        * Lives with: Respondent
+        % elif item.lives_with == "someone_else":
+
+        * Lives with: Someone other than Petitioner or Respondent
+        % endif
         % endif
         % if item.parties_married_when_born:
 
-        Paternity established by ${ users[0] } and ${ other_parties[0] } being married when ${ item.familiar() } was born
+        * Paternity established by ${ users[0] } and ${ other_parties[0] } being married when ${ item.familiar() } was born
         % elif (not item.parties_married_when_born) and item.paternity == "by_court_order":
 
-        Paternity established by court order (Case \#${ item.paternity_case_number } - ${ item.paternity_case_court_name })
+        * Paternity established by court order (Case \#${ item.paternity_case_number } - ${ item.paternity_case_court_name })
         % elif (not item.parties_married_when_born) and item.paternity == "by_acknowledgment_of_parentage":
         
-        Paternity established by *Acknowledgment of Parentage*
+        * Paternity established by *Acknowledgment of Parentage*
         % elif (not item.parties_married_when_born) and item.paternity == "paternity_case_pending":
         
-        Paternity case still pending (Case \#${ item.paternity_case_number } - ${ item.paternity_case_court_name })
+        * Paternity case still pending (Case \#${ item.paternity_case_number } - ${ item.paternity_case_court_name })
         % endif
         % if item.has_order_in_effect:
 
-        Custody/parenting time order in effect (Case \#${ item.custody_case_number } - ${ item.custody_case_court })
+        * Custody/parenting time order in effect (Case \#${ item.custody_case_number } - ${ item.custody_case_court })
         % if item.parenting_time_order == "reasonable_parenting_time":
 
-        Parenting time order only says there will be "reasonable parenting time"
+        * Parenting time order only says there will be "reasonable parenting time"
         % elif item.parenting_time_order == "specific_times":
 
-        Parenting time order lists specific days and times
+        * Parenting time order lists specific days and times
         % elif item.parenting_time_order == "one_parent_supervised":
 
-        Parenting time order says ${ users[0] if item.who_has_supervised_time == "petitioner" else other_parties[0] } will be supervised by ${ item.who_supervises_parenting_time }
+        * Parenting time order says ${ users[0] if item.who_has_supervised_time == "petitioner" else other_parties[0] } will be supervised by ${ item.who_supervises_parenting_time }
         % elif item.parenting_time_order == "one_parent_no_parenting_time":
 
-        Parenting time order says ${ users[0] if item.parent_without_parenting_time == "petitioner" else other_parties[0] } does not have any parenting time
+        * Parenting time order says ${ users[0] if item.parent_without_parenting_time == "petitioner" else other_parties[0] } does not have any parenting time
         % endif
         % if item.physical_custody_by_order == 'sole_petitioner':
 
-        Custody: ${ users[0] } has sole custody
+        * Custody: ${ users[0] } has sole custody
         % elif item.physical_custody_by_order == 'sole_respondent':
 
-        Custody: ${ other_parties[0] } has sole custody
+        * Custody: ${ other_parties[0] } has sole custody
         % elif item.physical_custody_by_order == 'joint_custody':
 
-        Custody: ${ users[0] } and ${ other_parties[0] } share custody
+        * Custody: ${ users[0] } and ${ other_parties[0] } share custody
         % endif
         % if not custody_parenting_time_provisions_same:
         % if item.desired_parenting_time_changes == "no_change":
 
-        Desired parenting time changes: None
+        * Desired parenting time change: None
         % elif item.desired_parenting_time_changes == "no_change_except_exchange":
 
-        Desired parenting time change: No change to parenting time, but exchange should take place at ${ item.exchange_police_department_location if item.exchange_location == "police" else item.exchange_other_location }
+        * Desired parenting time change: No change to parenting time, but exchange should take place at ${ item.exchange_police_department_location if item.exchange_location == "police" else item.exchange_other_location }
         % elif item.desired_parenting_time_changes == "suspend_respondent_time":
 
-        Desired parenting time change: ${ other_parties }'s parenting time should be suspended
+        * Desired parenting time change: ${ other_parties }'s parenting time should be suspended
         % endif
         % endif
         % endif
@@ -900,19 +911,46 @@ edit:
   - phone_number
 confirm: True
 ---
-table: children.table
-rows: children
+# table: children.table
+# rows: children
+# columns:
+#   - Name: |
+#       row_item.name_full()
+#   - Birthdate: |
+#       row_item.birthdate
+# edit:
+#   - name.first
+#   - lives_with
+#   - parties_married_when_born
+#   - has_order_in_effect
+# confirm: True
+---
+event: |-
+  children.revisit
+id: |-
+  revisit children
+question: |-
+  Edit answers about Children
+subquestion: |-
+  ${ children.table }
+  ${ children.add_action() }
+---
 columns:
-  - Name: |
-      row_item.name_full()
-  - Birthdate: |
-      row_item.birthdate
+  - 'Name': |-
+      row_item.name if hasattr(row_item, 'name') else ''
+  - 'DOB': |-
+      row_item.birthdate if hasattr(row_item, 'birthdate') else ''
+  - 'Lives with': |-
+      row_item.lives_with if hasattr(row_item, 'lives_with') else ''
+rows: |-
+  children
+table: |-
+  children.table
 edit:
   - name.first
   - lives_with
   - parties_married_when_born
   - has_order_in_effect
-confirm: True
 ---
 table: petitioner_other_children.table
 rows: petitioner_other_children

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -108,53 +108,80 @@ review:
         **Est. Age:** ${ item.estimated_age }[BR]
         (If you need to change ${ item.name }'s age, please use the **Undo** button or start over from the beginning.)
         % endif
-        % if item.race:
-
-        **Race:** ${ item.race }
-        % endif
-        % if item.gender:
-
-        **Gender:** ${ item.gender }
-        % endif
-        % if item.height:
-
-        **Height:** ${ item.height }
-        % endif
-        % if item.weight:
-
-        **Weight:** ${ item.weight }
-        % endif
-        % if item.hair_color:
-
-        **Hair Color:** ${ item.hair_color }
-        % endif
-        % if item.eye_color:
-
-        **Eye Color:** ${ item.eye_color }
-        % endif
-        % if item.license_number:
-
-        **License Number:** ${ item.license_number }
-        % endif
-        % if item.other_identifying_info:
-
-        **Other Identifying Info:** ${ item.other_identifying_info }
-        % endif
-        % if item.carries_gun_for_work == "unknown":
-
-        **Carries gun for work?:** Unknown
-        % elif item.carries_gun_for_work == "no":
-
-        **Carries gun for work?:** No
-        % elif item.carries_gun_for_work == "yes":
-
-        **Carries gun for work?:** Yes
-        % endif
 
         **Address:** ${ item.address.on_one_line() }
         
         **Phone:** ${ word("") if item.no_phone_number else item.phone_numbers() }
       % endfor
+  - Edit: other_parties[0].gender
+    button: |-
+      **What is the Respondent's gender?**
+      % if other_parties[0].gender == "M":
+      Male
+      % elif other_parties[0].gender == "F":
+      Female
+      % endif
+  - Edit: other_parties[0].race
+    button: |-
+      **What is the Respondent's race?**
+
+      ${ other_parties[0].race }
+  - Edit: other_parties[0].height_feet
+    button: |-
+      **What is the Respondent's height?**
+
+      ${ other_parties[0].height }
+  - Edit: other_parties[0].weight
+    button: |-
+      **What is the Respondent's weight?**
+
+      ${ other_parties[0].weight } lbs
+  - Edit: other_parties[0].hair_color
+    button: |-
+      **What is the Respondent's hair color?**
+
+      ${ other_parties[0].hair_color }
+  - Edit: other_parties[0].eye_color
+    button: |-
+      **What is the Respondent's eye color?**
+
+      ${ other_parties[0].eye_color }
+  - Edit: other_parties[0].license_number
+    button: |-
+      **What is the Respondent's license number?**
+      % if other_parties[0].license_number:
+
+      ${ other_parties[0].license_number }
+      % else:
+
+      *You have not entered a license number yet.*
+      % endif
+    show if: defined('other_parties[0].license_number')
+  - Edit: other_parties[0].other_identifying_info
+    button: |-
+      **Do you have any other identifying information for the Respondent?**
+      % if other_parties[0].other_identifying_info:
+
+      ${ other_parties[0].other_identifying_info }
+      % else:
+
+      *You have not entered any other identifying information yet.*
+      % endif
+    show if: defined('other_parties[0].other_identifying_info')
+  - Edit: other_parties[0].carries_gun_for_work
+    button: |-
+      **Does the Respondent carry a gun for work?**
+        % if other_parties[0].carries_gun_for_work == "unknown":
+
+        I don't know
+        % elif other_parties[0].carries_gun_for_work == "no":
+
+        No
+        % elif other_parties[0].carries_gun_for_work == "yes":
+
+        Yes
+        % endif
+    show if: defined('other_parties[0].carries_gun_for_work')
   - Edit: other_party_alias.there_are_any
     button: |-
       **Does the Respondent have any aliases?**
@@ -821,31 +848,10 @@ columns:
       row_item.phone_number
   - Age: |
       row_item.age_in_years() if defined("row_item.birthdate") else row_item.estimated_age
-  - Race: |
-      row_item.race
-  - Gender: |
-      row_item.gender
-  - Height: |
-      row_item.height
-  - Weight: |
-      row_item.weight
-  - Hair Color: |
-      row_item.hair_color
-  - Eye Color: |
-      row_item.eye_color
-  - License Number: |
-      row_item.license_number if defined("row_item.license_number") else ""
 edit:
   - name.first
   - address.address
   - phone_number
-  - race
-  - gender
-  - height_feet
-  - weight
-  - hair_color
-  - eye_color
-  - license_number
 confirm: True
 ---
 table: children.table


### PR DESCRIPTION
- Fixed #225 
- Broke up respondent review block into separate questions
- Edited formatting of children review block for visual clarity
- Edited tables to limit variables displayed when user goes to edit objects
- Added 'complete' attribute to children table to ensure logic is recomputed correctly when variables are changed
- Reviewed other groups that use tables in the review screen and made sure there was no cramming of attributes