### PR TITLE
Edits to PR #268

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -95,7 +95,7 @@ review:
         **${ item }**
 
         % if knows_respondents_birthdate:
-        **Age:** ${ item. }[BR]
+        **Age:** ${ item.age_in_years() }[BR]
         (If you need to change ${ item.name }'s age, please use the **Undo** button or start over from the beginning.)
         % else:
         **Est. Age:** ${ item.estimated_age }[BR]
@@ -917,8 +917,9 @@ columns:
       row_item.address.block()
   - Phone: |
       row_item.phone_number
-  - Age: |
-      row_item.age_in_years() if defined("row_item.birthdate") else row_item.estimated_age
+# just commenting out for now since age editing still in flux
+#  - Age: |
+#      row_item.age_in_years() if defined("row_item.birthdate") else row_item.estimated_age
 edit:
   - name.first
   - address.address

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -95,7 +95,7 @@ review:
         **${ item }**
 
         % if knows_respondents_birthdate:
-        **Age:** ${ item.age_in_years() }[BR]
+        **Age:** ${ item. }[BR]
         (If you need to change ${ item.name }'s age, please use the **Undo** button or start over from the beginning.)
         % else:
         **Est. Age:** ${ item.estimated_age }[BR]
@@ -871,6 +871,13 @@ subject: |
 content: |
   ${ exhibit_attachment.exhibits.rearrange_exhibits_table }
 ---
+id: users revisit
+question: |
+  Edit your answers about yourself
+subquestion: |
+  ${ users.table }
+continue button field: users.revisit
+---
 table: users.table
 rows: users
 columns:
@@ -883,7 +890,7 @@ columns:
 edit:
   - name.first
   - address.address
-confirm: True
+delete buttons: False
 ---
 table: next_friends.table
 rows: next_friends
@@ -893,6 +900,13 @@ columns:
 edit:
   - name.first
 confirm: True
+---
+id: other parties revisit
+question: |
+  Edit your answers about the person you need protection from (the respondent)
+subquestion: |
+  ${ other_parties.table }
+continue button field: other_parties.revisit
 ---
 table: other_parties.table
 rows: other_parties
@@ -909,7 +923,7 @@ edit:
   - name.first
   - address.address
   - phone_number
-confirm: True
+delete buttons: False
 ---
 continue button field: |-
   children.revisit

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -71,17 +71,11 @@ review:
 
       ${ word(yesno(petitioner_lives_in_michigan)) }
   - Edit: 
-      - next_friends.revisit
+      - next_friends[0].name.first
       - recompute:
         - reset_next_friend
     button: |-
-      % if len(next_friends.complete_elements()) > 0:
-      % for item in next_friends:
-      **Next Friend:**  ${ item }
-      % endfor
-      % else:
-      *You have not named anyone as your Next Friend yet.*
-      % endif
+      **Next Friend:**  ${ next_friends[0] }
     show if: next_friends.there_are_any
   - raw html: |
       ${ next_accordion('<h2 class="h5">Respondent</h2>') }
@@ -891,15 +885,6 @@ edit:
   - name.first
   - address.address
 delete buttons: False
----
-table: next_friends.table
-rows: next_friends
-columns:
-  - Name: |
-      row_item.name_full()
-edit:
-  - name.first
-confirm: True
 ---
 id: other parties revisit
 question: |


### PR DESCRIPTION
- Remove delete and add another options from user and other_parties tables since they both must always have exactly one member of the list, which should not be deleted
- remove age from other_parties table since it's not currently editable and don't want to give impression it is
- ditched table for next_friend because it only edits a single screen and should only ever have one list member. No need for table.

(note, could maybe ditch tables for users and other_parties too since they mostly just add an extra click to edit)