### PR TITLE
Update Review Screen e-signature logic

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -814,11 +814,6 @@ code: |
 
 #   check_oakland_respondent_contact_info = True
 ---
-# code: |
-#   reconsider('signature_date')
-# 
-#   reset_signature_date = True
----
 code: |
   if (ppo_type == "nondomestic" and (county_choice == "Wayne" or county_choice == "Oakland")) or \
   (ppo_type == "nondomestic_sexual_assault" and county_choice == "Oakland") or \

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -814,11 +814,10 @@ code: |
 
 #   check_oakland_respondent_contact_info = True
 ---
-code: |
-  if not MLH_esign:
-    undefine('signature_date')
-
-  reset_signature_date = True
+# code: |
+#   reconsider('signature_date')
+# 
+#   reset_signature_date = True
 ---
 code: |
   if (ppo_type == "nondomestic" and (county_choice == "Wayne" or county_choice == "Oakland")) or \
@@ -1813,7 +1812,7 @@ subquestion: |
 
   This tool can put "**/s/ ${ users[0] }**" and "**/s/ ${ next_friends[0] }**" where you would sign your names so you do not have to sign the forms by hand. The court will accept these electronic signatures.
 fields:
-  - Does ${ users[0] }, agree to add their electronic signature to the *Request for Next Friend* now?: fourteen_plus_agrees_to_sign
+  - Does ${ users[0] } agree to add their electronic signature to the *Request for Next Friend* now?: fourteen_plus_agrees_to_sign
     datatype: yesnoradio
   - Does the next friend, ${ next_friends[0] }, agree to add their electronic signature to the other forms now?: next_friend_agrees_to_sign
     datatype: yesnoradio
@@ -4507,7 +4506,7 @@ attachments:
     - signature_date_requestor: |
         % if petitioner_is_minor and (not petitioner_under_fourteen) and (not petitioner_is_emancipated_minor) and fourteen_plus_agrees_to_sign:
         ${ signature_date }
-        % elif is_incapacitated_adult or (petitioner_is_minor and petitioner_under_fourteen) and next_friend_agrees_to_sign:
+        % elif (is_incapacitated_adult or (petitioner_is_minor and petitioner_under_fourteen)) and next_friend_agrees_to_sign:
         ${ signature_date }
         % else:
         ${ '' }

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -802,15 +802,38 @@ review:
     show if: exhibit_attachment.exhibits.has_exhibits
   - raw html: |
       ${ next_accordion('<h2 class="h5">Electronic Signature</h2>') }
-    show if: defined('MLH_esign')
+    show if: (defined('MLH_esign') or defined('next_friend_agrees_to_sign')) and ETC_county_status != "required"
   - Edit:
       - MLH_esign
       - recompute:
-        - reset_signature_date
+        - signature_date
     button: |
       **Do you want to add your electronic signature?**
 
       ${ word(yesno(MLH_esign)) }
+    show if: ETC_county_status != "required" and (not is_incapacitated_adult and (not petitioner_is_minor or petitioner_is_emancipated_minor))
+  - Edit:
+      - next_friend_agrees_to_sign
+      - recompute:
+        - signature_date
+    button: |
+      **Does the next friend, ${ next_friends[0] }, agree to add their electronic signature?**
+
+      ${ word(yesno(next_friend_agrees_to_sign)) }
+    show if: ETC_county_status != "required" and (is_incapacitated_adult or (petitioner_is_minor and not petitioner_is_emancipated_minor and petitioner_under_fourteen ))
+  - Edit:
+      - fourteen_plus_agrees_to_sign
+      - recompute:
+        - signature_date
+    button: |
+      **Does ${ users[0] } agree to add their electronic signature to the *Request for Next Friend**?
+
+      ${ word(yesno(fourteen_plus_agrees_to_sign)) }
+      
+      **Does the next friend, ${ next_friends[0] }, agree to add their electronic signature to the other forms?**
+
+      ${ word(yesno(next_friend_agrees_to_sign)) }
+    show if: ETC_county_status != "required" and (petitioner_is_minor and not petitioner_is_emancipated_minor and not petitioner_under_fourteen )
   - raw html: |
       ${ end_accordion() }
     show if: is_incapacitated_adult or not is_incapacitated_adult

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -826,7 +826,7 @@ review:
       - recompute:
         - signature_date
     button: |
-      **Does ${ users[0] } agree to add their electronic signature to the *Request for Next Friend**?
+      **Does ${ users[0] } agree to add their electronic signature to the *Request for Next Friend***?
 
       ${ word(yesno(fourteen_plus_agrees_to_sign)) }
       


### PR DESCRIPTION
closes #266 (e-sign not editable in ETC required counties)
updates review screen review screen to support different signature types (depending on age, next friend status)
reset_signature_date not needed because signature_date is protected on form templates with conditional statements