### PR TITLE
Fix Review screen orders and judgments functionality

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -227,8 +227,7 @@ code: |
     if pending_actions.there_are_any:
       pending_actions.gather()
     pending_actions_asked
-    if orders_judgments.there_are_any:
-      orders_judgments.gather()
+    orders_judgments.gather()
     orders_judgments_asked
 
   nav.set_section("review_abuse_history_info")
@@ -248,7 +247,7 @@ code: |
     sexual_assault_intro
     if respondent_sexual_assault_conviction:
       orders_judgments.gather(minimum=1)
-    elif orders_judgments.there_are_any:
+    else:
       orders_judgments.gather()
     orders_judgments_asked
 

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -508,9 +508,9 @@ review:
       % endfor
       % else:
       % if ppo_type == "nondomestic_sexual_assault":
-      You have not listed any convictions, orders, or judgments yet.
+      You have not listed any convictions, orders, or judgments yet. Tap **Edit** to add one.
       % else:
-      You have not listed any orders or judgments yet.
+      You have not listed any orders or judgments yet. Tap **Edit** to add one.
       % endif
       % endif
     show if: orders_judgments.there_are_any or not orders_judgments.there_are_any

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -486,6 +486,7 @@ review:
       % else:
       Court orders or judgments regarding you and ${ other_parties[0] }:
       % endif
+    show if: defined('orders_judgments.there_are_any')
   - Edit:
       - orders_judgments.revisit
       - recompute:
@@ -508,9 +509,9 @@ review:
       % endfor
       % else:
       % if ppo_type == "nondomestic_sexual_assault":
-      You have not listed any convictions, orders, or judgments yet. Tap **Edit** to add one.
+      No convictions, orders, or judgments. Tap **Edit** to add one.
       % else:
-      You have not listed any orders or judgments yet. Tap **Edit** to add one.
+      No orders or judgments. Tap **Edit** to add one.
       % endif
       % endif
     show if: orders_judgments.there_are_any or not orders_judgments.there_are_any


### PR DESCRIPTION
To make the review/edit logic work to **require** a sexual assault conviction if the user says there is one, I messed with the normal review screen pattern and set it up to always display the revisit block instead of having a yes/no and then the revisit block only if there are any orders/judgments already listed (like for pending cases). See #262. That change introduced this bug. 

(The main issue was that the way our gather logic was set up, the [.revisit attribute](https://docassemble.org/docs/groups.html#editing) of the list was not getting defined because .gather() was never called. I suspect asking .there_are_any before .gather() is often unnecessary in the code, but it's generally not hurting anything. But here it was preventing generation of the revisit button.)

Tested the described issues and is working now. I also simplified the language a bit to try to make it more readable.

Fixes #296, fixes #282, fixes #317