### PR TITLE
Added missing name tag in CC 396m attachment block

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -5613,6 +5613,7 @@ attachments:
     - other_parties1_name__3: ${ other_parties[0].name_full() }
     - other_parties1_name__4: ${ other_parties[0].name_full() }
     - other_parties1_address_block: |
+        ${ other_parties[0].name_full() }
         ${ other_parties[0].address.line_one() }
         ${ other_parties[0].address.line_two() }
         % if other_parties[0].no_phone_number:


### PR DESCRIPTION
- Fixed #373 by adding missing other_party name tag in attachment block for CC 396M.
- Checked orders generated in other pathways to make sure no other forms were missing the respondent's name in the address block.