### PR TITLE
file upload setting experiment and update relationship question

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -2022,6 +2022,27 @@ validation code: |
     x[0].pages.complete_attribute = 'ok'
     x[0].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
+# overriding version from ql_baseline
+generic object: ALExhibitList
+id: exhibit i has additional pages
+question: |
+  Add more pages to "**${ x[i] }**"?
+subquestion: |
+  % if hasattr(x, 'maximum_size'):
+  The total size of all exhibits must be less than ${ humanize.naturalsize(x.maximum_size) }.
+  You can upload ${ humanize.naturalsize(x.maximum_size - x.size_in_bytes() - sum(ap.size_in_bytes() for ap in x[i].pages.complete_elements()))} more.
+  % endif
+
+  ${ collapse_template(x[i].in_progress_template )}
+  
+fields: 
+  - Do you want to add more pages to "**${ x[i] }**"?: x[i].pages.there_is_another
+    datatype: radio
+    choices:
+      - Yes, I want to add more pages to "${ x[i] }".: True
+      - No, there are no more pages to add to "${ x[i] }".: False
+    label above field: True
+---
 # overriding version from ql_baseline (only changed max image size)
 sets:
   - x[i].pages[j].initialized
@@ -2057,6 +2078,26 @@ validation code: |
     validation_error("Unable to convert this file. Please upload a new one.")
 
   x[i].pages[j] = unpack_dafilelist(x[i].pages[j])
+---
+# overriding version from ql_baseline
+generic object: ALExhibitList
+id: another exhibit
+question: |
+  You have ${ x.number_gathered() } document(s) so far. Do you want to upload another document?
+subquestion: |
+  % if hasattr(x, 'maximum_size'):
+  The total size of all exhibits must be less than ${ humanize.naturalsize(x.maximum_size) }.
+  You can upload ${ humanize.naturalsize(x.maximum_size - x.size_in_bytes())} more.
+  % endif
+
+  ${ collapse_template(x.in_progress_exhibits) }
+fields: 
+  - Upload another document?: x.there_is_another
+    datatype: radio
+    choices:
+      - Yes, I want to add another.: True
+      - No, I'm done adding documents.: False
+    label above field: True
 ---
 # overriding version from ql_baseline (only changed max image size and text)
 generic object: ALExhibitList
@@ -2120,6 +2161,8 @@ content: |
   Scan paper documents with a scanner app or a physical scanner to create clean PDF copies.
 
   It's OK to upload photos or screenshots from phones.
+
+  Accepted file types: PDF, JPG, PNG, and word-processing files such as DOCX.
 ---
 id: petitioner or respondent living in michigan
 question: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -2035,7 +2035,7 @@ validation code: |
     x[0].pages.complete_attribute = 'ok'
     x[0].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
-# overriding version from ql_baseline
+# overriding version from ql_baseline (only changed max image size)
 sets:
   - x[i].pages[j].initialized
   - x[i].pages[j].mimetype
@@ -2069,6 +2069,7 @@ validation code: |
 
   x[i].pages[j] = unpack_dafilelist(x[i].pages[j])
 ---
+# overriding version from ql_baseline (only changed max image size)
 generic object: ALExhibitList
 id: exhibit i
 question: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1945,6 +1945,15 @@ content: |
   Yes. Because these forms will be e-mailed directly to the court, e-signatures are required. 
   % endif
 ---
+template: efiling_info_template
+subject: Can I e-file?
+content: |
+  Only some courts and case types allow e-filing using ${ MLH_MiFILE } or another e-filing system. 
+  
+  [Find out if your court has electronic filing for your case type.](https://sw0lylcelhb.typeform.com/to/HXBVb68q) For more information, read [What is E-Filing?](https://michiganlegalhelp.org/resources/mifile/what-e-filing).
+  
+  ${ MLH_case_type_language }
+---
 # overriding version from ql_baseline
 generic object: ALExhibitList
 id: any exhibits
@@ -2025,6 +2034,70 @@ validation code: |
       validation_error("Unable to convert this file. Please upload a new one.")
     x[0].pages.complete_attribute = 'ok'
     x[0].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
+---
+# overriding version from ql_baseline
+sets:
+  - x[i].pages[j].initialized
+  - x[i].pages[j].mimetype
+  - x[i].pages[j].ok
+generic object: ALExhibitList
+id: exhibit additional page
+question: |
+  Upload the ${ ordinal(j) } part of your ${ x[i].title } document
+fields:
+  - Upload a PDF, Word, or image file: x[i].pages[j]
+    datatype: file
+    maximum image size: 2048
+    image upload type: jpeg
+    accept: |
+      "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"   
+validation code: |
+  page_size = x[i].pages[j].size_in_bytes()
+  if page_size > (15 * 1024 * 1024):
+    validation_error("Upload a file smaller than 15 MB.")
+  if hasattr(x, 'maximum_size'):
+    # this_doc_size already includes `page_size`
+    this_doc_size = sum(a_page.size_in_bytes() for a_page in x[i].pages.complete_elements())
+    full_size = x.size_in_bytes() + this_doc_size
+    if full_size > x.maximum_size:
+      suggested_size = x.maximum_size - (full_size - page_size)
+      validation_error(f"All exhibits combined must be smaller than {humanize.naturalsize(x.maximum_size)}. Upload a file smaller than {humanize.naturalsize(suggested_size)}.")
+  try:
+    pdf_concatenate(x[i].pages[j])
+  except:
+    validation_error("Unable to convert this file. Please upload a new one.")
+
+  x[i].pages[j] = unpack_dafilelist(x[i].pages[j])
+---
+generic object: ALExhibitList
+id: exhibit i
+question: |
+  Upload the ${ ordinal(i) } document
+subquestion: |
+  You will have a chance to upload additional pages for this document later.
+fields:
+  - Document title: x[i].title
+    maxlength: 60 # longer might break TOC
+  - Upload the exhibit: x[i].pages
+    datatype: files
+    maximum image size: 2048
+    image upload type: jpeg
+    accept: |
+      "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"   
+validation code: |
+  this_doc_size = sum(a_page.size_in_bytes() for a_page in x[i].pages)
+  if this_doc_size > (15 * 1024 * 1024):
+    validation_error("Upload a file smaller than 15 MB.")
+  if hasattr(x, 'maximum_size'):
+    full_size = x.size_in_bytes()
+    if full_size > x.maximum_size:
+      suggested_size = x.maximum_size - (full_size - this_doc_size)
+      validation_error(f"All exhibits combined must be smaller than {humanize.naturalsize(x.maximum_size)}. Upload a file smaller than {humanize.naturalsize(suggested_size)}.")
+  try:
+    pdf_concatenate(x[i].pages)
+  except:
+    validation_error("Unable to convert this file. Please upload a new one.")
+  x[i].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
 template: audiovisual_evidence
 subject: |
@@ -4328,7 +4401,7 @@ under: |
 
   ${ sign_in_message }
 ---
-id: ETC required, collect email
+id: ETC , collect email
 continue button field: ETC_required_email_collect
 question: |
   Contact E-mail

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -4411,7 +4411,7 @@ under: |
 
   ${ sign_in_message }
 ---
-id: ETC , collect email
+id: ETC required, collect email
 continue button field: ETC_required_email_collect
 question: |
   Contact E-mail

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1587,22 +1587,35 @@ continue button field: minimum_incidents_explainer
 ---
 id: describe relationship to respondent
 question: |
+  % if ppo_type == "domestic":
   Your relationship with ${ other_parties[0] }
+  % else:
+  Is ${ other_parties[0] } someone you know?
+  % endif
 subquestion: |
-  For example:
+  Please explain. For example:
 
     % if ppo_type == "domestic":
     * "The respondent and I are siblings."
     * "The respondent and I used to be roomates. We are not related to each other."
     % else:
+    * "I don't know the respondent. They are a stranger."
     * "The respondent is my neighbor."
     * "The respondent used to be my co-worker."
     % endif
 
   *Use complete sentences and proper punctuation. Your answer will appear in your forms exactly as you type it.*
 fields:
-  - Describe your relationship with ${ other_parties[0] }: relationship_to_respondent_exp
+  - Describe your relationship with ${ other_parties[0] }:: relationship_to_respondent_exp
     datatype: area
+    show if:
+      code: |
+        ppo_type == "domestic"
+  - Describe how you know ${ other_parties[0] }, if at all:: relationship_to_respondent_exp
+    datatype: area
+    show if:
+      code: |
+        ppo_type != "domestic"
 ---
 id: petitioner alias there_are_any
 question: |
@@ -1994,7 +2007,7 @@ fields:
   - Upload the first document: x[0].pages
     show if: x.has_exhibits
     datatype: files
-    maximum image size: 1024
+    maximum image size: 2048
     image upload type: jpeg
     accept: |
       "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -2002,13 +2002,14 @@ subquestion: |
   % endif
 
   ${ collapse_template(no_documents) }
+  ${ collapse_template(paper_documents) }
   ${ collapse_template(audiovisual_evidence) }
 fields:
   - Do you have any documents you want to upload?: x.has_exhibits
     datatype: yesnoradio
   - note: |
       **Okay**. You will have a chance to upload multiple documents. 
-      You can also add additional pages to this document.
+      You can also add more pages to this document.
     show if: x.has_exhibits
   - First document title: x[0].title
     maxlength: 60 # longer might break TOC
@@ -2069,13 +2070,13 @@ validation code: |
 
   x[i].pages[j] = unpack_dafilelist(x[i].pages[j])
 ---
-# overriding version from ql_baseline (only changed max image size)
+# overriding version from ql_baseline (only changed max image size and text)
 generic object: ALExhibitList
 id: exhibit i
 question: |
   Upload the ${ ordinal(i) } document
 subquestion: |
-  You will have a chance to upload additional pages for this document later.
+  You will have a chance to upload more pages for this document later.
 fields:
   - Document title: x[i].title
     maxlength: 60 # longer might break TOC
@@ -2111,6 +2112,16 @@ subject: |
   What if don't have any documents to attach?
 content: |
   Even if you don't have any documents to attach, you can still file your petition. The judge shouldn't deny a petition just because you don't have any documents to attach.
+---
+template: paper_documents
+subject: |
+  I have a paper document. How can I upload it?
+content: |
+  If possible, scan paper documents using a **scanner app** on your phone or a **physical scanner** to create clean PDF copies. 
+
+  Examples of free scanner apps are Adobe Scan, Google Drive, or Apple Notes. (Note, we do not recommend any specific software. You can use other methods to create PDFs as well.)
+
+  If possible, **do not** simply upload a photo of your document. It may come out small and hard to read.
 ---
 id: petitioner or respondent living in michigan
 question: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1945,15 +1945,6 @@ content: |
   Yes. Because these forms will be e-mailed directly to the court, e-signatures are required. 
   % endif
 ---
-template: efiling_info_template
-subject: Can I e-file?
-content: |
-  Only some courts and case types allow e-filing using ${ MLH_MiFILE } or another e-filing system. 
-  
-  [Find out if your court has electronic filing for your case type.](https://sw0lylcelhb.typeform.com/to/HXBVb68q) For more information, read [What is E-Filing?](https://michiganlegalhelp.org/resources/mifile/what-e-filing).
-  
-  ${ MLH_case_type_language }
----
 # overriding version from ql_baseline
 generic object: ALExhibitList
 id: any exhibits
@@ -1982,10 +1973,7 @@ subquestion: |
   * Copies of e-mails or text messages
   * Letters
 
-  If you plan to file by direct e-mail from this tool, attach any documents now. If you plan to file in a different way, you can choose to:
-
-  * upload documents using this tool, or
-  * attach documents yourself outside of this tool.
+  If you plan to file by direct e-mail from this tool, attach any documents now. If you plan to file in a different way, you can upload documents now or attach documents yourself outside of this tool.
   % else:
   If you have any documents you want to show the judge, you can attach them now. This could include things like:
 
@@ -1995,10 +1983,7 @@ subquestion: |
   * Copies of e-mails or text messages
   * Letters
 
-  You can choose to:
-
-  * upload documents using this tool, or
-  * attach documents yourself after you get your forms.
+  You can upload documents now or attach documents yourself outside of this tool.
   % endif
 
   ${ collapse_template(no_documents) }
@@ -2008,8 +1993,9 @@ fields:
   - Do you have any documents you want to upload?: x.has_exhibits
     datatype: yesnoradio
   - note: |
-      **Okay**. You will have a chance to upload multiple documents. 
-      You can also add more pages to this document.
+      **Okay**. You can upload multiple documents. You can also add more pages to this document.
+
+      ${ collapse_template(preferred_file_types) }
     show if: x.has_exhibits
   - First document title: x[0].title
     maxlength: 60 # longer might break TOC
@@ -2045,6 +2031,8 @@ generic object: ALExhibitList
 id: exhibit additional page
 question: |
   Upload the ${ ordinal(j) } part of your ${ x[i].title } document
+subquestion: |
+  ${ collapse_template(preferred_file_types) }
 fields:
   - Upload a PDF, Word, or image file: x[i].pages[j]
     datatype: file
@@ -2077,6 +2065,8 @@ question: |
   Upload the ${ ordinal(i) } document
 subquestion: |
   You will have a chance to upload more pages for this document later.
+
+  ${ collapse_template(preferred_file_types) }
 fields:
   - Document title: x[i].title
     maxlength: 60 # longer might break TOC
@@ -2103,25 +2093,33 @@ validation code: |
 ---
 template: audiovisual_evidence
 subject: |
-  What if I have audio or video evidence?
+  What if I have **audio or video** evidence?
 content: |
   Save any audio or video evidence you have. If there will be a hearing for your case, you can submit the audio or video evidence to the court directly.
 ---
 template: no_documents
 subject: |
-  What if don't have any documents to attach?
+  What if **don't** have any documents to attach?
 content: |
   Even if you don't have any documents to attach, you can still file your petition. The judge shouldn't deny a petition just because you don't have any documents to attach.
 ---
 template: paper_documents
 subject: |
-  I have a paper document. How can I upload it?
+  How do I upload a **paper document**?
 content: |
-  If possible, scan paper documents using a **scanner app** on your phone or a **physical scanner** to create clean PDF copies. 
+  Scan paper documents using a **scanner app** on your phone or a **physical scanner** to create clean PDF copies. 
 
-  Examples of free scanner apps are Adobe Scan, Google Drive, or Apple Notes. (Note, we do not recommend any specific software. You can use other methods to create PDFs as well.)
+  Examples of free scanner apps are Adobe Scan, Google Drive, or Apple Notes. (We do not recommend any specific software. You can create PDFs in other ways as well.) Some libraries also have scanners.
+---
+template: preferred_file_types
+subject: |
+  File type tips
+content: |
+  If possible, upload documents as PDFs to help avoid issues. In many cases, "save", "print", "download", or "share" options include a way to create a PDF. To learn more, read [Working with PDF Files](https://michiganlegalhelp.org/resources/mifile/working-pdf-files). 
 
-  If possible, **do not** simply upload a photo of your document. It may come out small and hard to read.
+  Scan paper documents with a scanner app or a physical scanner to create clean PDF copies.
+
+  It's OK to upload photos or screenshots from phones.
 ---
 id: petitioner or respondent living in michigan
 question: |


### PR DESCRIPTION
- moves document upload questions into interview from ql_baseline in order to:
  - Increase maximum file size on upload screens so that images uploaded come out larger (but still smaller than a standard page)
  - Adjust the way the "is there another?" questions are asked to be simpler and to fit our usual method of advancing the interview (choices with continue button)
  - remove statement about how many pages you've already uploaded because it was inaccurate for docx files
- Adjusts and adds download screen tips and info
- (unrelated) update to relationship to respondent question to make it accommodate unknown respondents