### PR TITLE
Make age editable and deal with new PPO_type selection method on review screen

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -125,22 +125,7 @@ code: |
     user.birthdate
 
   check_if_petitioner_minor
-  if petitioner_is_minor:
-    if is_incapacitated_adult:
-      inconsistent_age_kickout
-    else:
-      if petitioner_at_least_sixteen:
-        petitioner_is_emancipated_minor
-
-      if not petitioner_is_emancipated_minor:
-        if next_friends.there_are_any:
-          next_friends.gather()
-          if next_friend_agrees_to_role:
-            set_next_friend
-          else:
-            next_friend_role_kickout
-        else:
-          minor_kickout
+  minor_petitioner_initial_logic
 
   knows_respondents_birthdate
 
@@ -419,6 +404,26 @@ code: |
     petitioner_at_least_sixteen = False
     petitioner_is_emancipated_minor = False
   check_if_petitioner_minor = True
+---
+code: |
+  if petitioner_is_minor:
+    if is_incapacitated_adult:
+      inconsistent_age_kickout
+    else:
+      if petitioner_at_least_sixteen:
+        petitioner_is_emancipated_minor
+
+      if not petitioner_is_emancipated_minor:
+        if next_friends.there_are_any:
+          next_friends.gather()
+          if next_friend_agrees_to_role:
+            set_next_friend
+          else:
+            next_friend_role_kickout
+        else:
+          minor_kickout
+
+  minor_petitioner_initial_logic = True
 ---
 code: |
   if knows_respondents_birthdate:
@@ -833,6 +838,8 @@ code: |
   relationship_choices.append({'dating':'We dated or are dating'}) 
   if parent_choice: 
     relationship_choices.append({'parent':'They are my parent and we live together (or used to live together)'})
+
+  populate_relationship_choices_list = True
 ---
 code: |
   if other_parties_parents[i].shares_respondent_address:
@@ -1068,15 +1075,6 @@ code: |
 code: |
   ppo_sexual_assault_threat_protectees[i].name.first
   ppo_sexual_assault_threat_protectees[i].complete = True
----
-code: |
-  if is_incapacitated_adult:
-    next_friends.there_are_any = True
-  elif petitioner_is_minor:
-    if not petitioner_is_emancipated_minor:
-      next_friends.there_are_any = True
-
-  reset_next_friend = True
 ---
 code: |
   if not pending_actions.there_are_any:

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -51,8 +51,6 @@ review:
       % for item in users:
         **${ item }**
 
-        **Age:** ${ users[0].age_in_years() }[BR]
-
         **Address:** ${ item.address.on_one_line() }
 
         **Phone:** ${ word("None") if item.no_phone_number else item.phone_numbers() }
@@ -1114,12 +1112,9 @@ columns:
       row_item.address.block()
   - Phone: |
       row_item.phone_number
-  - Age: |
-      row_item.age_in_years()
 edit:
   - name.first
   - address.address
-  - birthdate
 delete buttons: False
 ---
 continue button field: |-

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -25,6 +25,25 @@ review:
       If you need to change this, please use the **Undo** button or start over from the beginning.
     show if: is_incapacitated_adult
   - Edit: 
+      - users[0].birthdate
+      - other_parties[0].birthdate
+      - recompute:
+        - check_if_petitioner_minor
+        - check_if_respondent_minor
+        - respondent parent addresses etc. logic
+        - county_choice options logic/warning based on respondent age
+        - minor_petitioner_initial_logic
+        - set_relationship_choices
+        - populate_relationship_choices_list
+      - follow up:
+        - petitioner_respondent_relationship
+      - recompute:
+        - reset_relationship_description
+        - set_petitioner_respondent_relationship
+    button: |-
+      **Your age**: ${ users[0].age_in_years() }[BR]
+      ** Respondent's age**: ${ other_parties[0].age_in_years() }
+  - Edit: 
       - users.revisit
       - recompute:
         - check_parties_living_together
@@ -33,7 +52,6 @@ review:
         **${ item }**
 
         **Age:** ${ users[0].age_in_years() }[BR]
-        (If you need to change your age, please use the **Undo** button or start over from the beginning.)
 
         **Address:** ${ item.address.on_one_line() }
 
@@ -78,8 +96,6 @@ review:
       ${ word(yesno(petitioner_lives_in_michigan)) }
   - Edit: 
       - next_friends[0].name.first
-      - recompute:
-        - reset_next_friend
     button: |-
       **Next Friend:**  ${ next_friends[0] }
     show if: next_friends.there_are_any
@@ -1098,9 +1114,12 @@ columns:
       row_item.address.block()
   - Phone: |
       row_item.phone_number
+  - Age: |
+      row_item.age_in_years()
 edit:
   - name.first
   - address.address
+  - birthdate
 delete buttons: False
 ---
 continue button field: |-


### PR DESCRIPTION
initial, now out of date attempt to start fixing #251 

If we do want to allow petition type editing, we could try doing it on the review screen with an edit button for petitioner_respondent_relationship and a series of follow-ups and recomputes for the remaining logic. And "if:" statements on the screens themselves.
