### PR TITLE
Added period to area fields without question mark or ellipsis

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -2990,7 +2990,7 @@ fields:
       - I did: petitioner
       - ${ other_parties[0] } did: respondent
       - Someone else did: third_party 
-  - Please explain:: children[i].third_party_birthing_parent_exp
+  - Please explain.: children[i].third_party_birthing_parent_exp
     input type: area
     show if:
       variable: children[i].birthing_parent
@@ -3215,7 +3215,7 @@ fields:
       - I want to keep the current custody and parenting time arrangements. They should continue as ordered in the divorce judgment and/or custody order, **BUT** I think the exchange of ${ children[0].familiar() } should happen at a neutral place.: no_change_except_exchange
       - I think that ${ children[0].familiar() }'s safety is at risk. I would like to stop all parenting time between ${ other_parties[0] } and ${ children[0].familiar() }.: suspend_respondent_time
       - Something else.: something_else
-  - Explain how you want the current parenting time arrangements to change:: parenting_time_changes_exp
+  - Explain how you want the current parenting time arrangements to change.: parenting_time_changes_exp
     input type: area
     show if:
       variable: desired_parenting_time_changes
@@ -3233,7 +3233,7 @@ fields:
       - I want to keep the current parenting time arrangements, **BUT** I think the exchange of ${ children[0].familiar() } should happen at a neutral place.: no_change_except_exchange
       - I think that ${ children[0].familiar() }'s safety is at risk. I would like to stop all parenting time between ${ other_parties[0] } and ${ children[0].familiar() }.: suspend_respondent_time
       - Something else.: something_else
-  - Explain how you want the current parenting time arrangements to change:: parenting_time_changes_exp
+  - Explain how you want the current parenting time arrangements to change.: parenting_time_changes_exp
     input type: area
     show if:
       variable: desired_parenting_time_changes
@@ -3251,7 +3251,7 @@ fields:
       - I want to keep the current parenting time arrangements, **BUT** I think parenting time exchanges should happen at a neutral place.: no_change_except_exchange
       - I think that the safety of the children is at risk. I would like to stop all parenting time between ${ other_parties[0] } and our minor children.: suspend_respondent_time
       - Something else.: something_else
-  - Explain how you want the current parenting time arrangements to change:: parenting_time_changes_exp
+  - Explain how you want the current parenting time arrangements to change.: parenting_time_changes_exp
     input type: area
     show if:
       variable: desired_parenting_time_changes
@@ -3518,7 +3518,7 @@ fields:
     show if: 
       variable: respondent_sexual_assault_conviction
       is: False
-  - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }: potential_sexual_assault_exp
+  - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }.: potential_sexual_assault_exp
     input type: area
     show if:
       variable: fears_future_sexual_assault
@@ -3573,7 +3573,7 @@ fields:
     show if: 
       variable: obscene_material_conviction
       is: False
-  - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }: potential_sexual_assault_exp
+  - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }.: potential_sexual_assault_exp
     input type: area
     show if:
       variable: fears_future_sexual_assault
@@ -3583,7 +3583,7 @@ fields:
     show if: 
       variable: fears_future_sexual_assault
       is: False
-  - Please explain what happened: obscene_material_exp
+  - Please explain what happened.: obscene_material_exp
     input type: area
     show if:
       variable: obscene_material_provided
@@ -4635,7 +4635,7 @@ fields:
       ${ contact_email }
       % endif
     datatype: email
-  - Notes for the court clerk (optional): notes_to_clerk
+  - Notes for the court clerk (optional).: notes_to_clerk
     input type: area
     rows: 3
     maxlength: 200


### PR DESCRIPTION
- Fixed #327. Added period at the end of every question description that used an area field, and which did not already use a question mark or ellipsis. 