### PR TITLE
add snapshot if ETC sending fails

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -391,6 +391,7 @@ code: |
       email_status_sent
       ETC_success
     else:
+      snapshot_ETC
       email_status_failed
       ETC_error
 


### PR DESCRIPTION
I confirmed that when you use the "undo" button, it undefines the snapshot trigger variable and stuff_to_snapshot associated with that trigger (tested on etc_download) in the interview, although the snapshot data itself appears to stay intact.

Have now successfully tested the new snapshot_ETC logic. If the email fails, you will get the top line in your snapshot data. If the user hits Undo, the data is retained. If the user resubmits and sending is successful, the snapshot data now looks like the 2nd line, with "False" now overwritten to "True" and modtime and ETC_time overwritten as well.
![image](https://github.com/user-attachments/assets/51f2c427-d979-496e-ba8a-bc9f3027491f)
