### PR TITLE
add date requirement to SA path; rework legally incapacitated adult question

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1806,7 +1806,7 @@ fields:
     datatype: radio
     choices:
       - I need a PPO to protect **myself**.: False
-      - I am the **legal guardian or power of attorney** for an **adult** who needs a PPO. I will sign and file the petition for them.: True
+      - I am the **legal guardian** or I have **power of attorney** for an **adult** who needs a PPO. I will sign and file the petition for them.: True
         help: |
           Choose this answer if the person who needs protection is an **adult** and:
           
@@ -1824,7 +1824,7 @@ fields:
       is: True
     label above field: True
   - note: |
-      **You must attach** guardianship or power of attorney paperwork to the petition.
+      **You must attach** guardianship or power of attorney documents to the petition.
     show if:
       variable: next_friends.there_are_any
       is: True

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1806,7 +1806,7 @@ fields:
     datatype: radio
     choices:
       - I need a PPO to protect **myself**.: False
-      - I am the **legal guardian or power of attorney** for an **adult** who needs a PPO. I will apply and sign the petition for them.: True
+      - I am the **legal guardian or power of attorney** for an **adult** who needs a PPO. I will sign and file the petition for them.: True
         help: |
           Choose this answer if the person who needs protection is an **adult** and:
           

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -25,6 +25,10 @@ terms:
       - respondents
     definition: |
       The Respondent is the person you want to be protected from.
+  - phrases:
+      - obscene material
+    definition: |
+      "Obscene material" may include things like a pornographic image or video. You may want to talk to a lawyer if you're not sure what happened would be considered giving obscene material.
 ---
 sections:
   - signpost_intro: "Introduction"
@@ -2371,7 +2375,7 @@ id: ppo type info
 question: |
   Type of Personal Protection Order (PPO)
 subquestion: |
-  In Michigan, there are three kinds of PPO. On the next few screens, we will ask questions to figure out if there is a PPO type that fits your situation. 
+  In Michigan, there are three kinds of PPOs. On the next few screens, we will ask questions to figure out if there is a PPO type that fits your situation. 
 
   ${ collapse_template(ppo_types_explained) }
 continue button field: ppo_type_info
@@ -2411,15 +2415,29 @@ fields:
 id: sexual assault facts (minor)
 if: petitioner_is_minor
 question: |
-  Sexual assault or obscene materials
+  Sexual assault or obscene material
 fields:
-  - "Has the {respondent} sexually assaulted you, threatened to sexually assault you, or given you obscene materials?": sexual_assault_facts
+  - "Has the {respondent} sexually assaulted you, threatened to sexually assault you, or given you obscene material?": sexual_assault_facts
     datatype: yesnoradio
+  - note: |
+      ${ collapse_template(minor_SA_screening_info) }
   - note: |
       OK, you will fill out the forms to request a **Nondomestic Sexual Assault** PPO.
     show if:
       variable: sexual_assault_facts
       is: True
+---
+template: minor_SA_screening_info
+subject: |
+  More information about answering this question
+content: |
+  Please answer "Yes" if the {respondent} did **any** of these things:
+
+  * sexually assaulted you;
+  * threatened to sexually assault you; **or**
+  * gave you {obscene material}.
+  
+  Any one of these things is enough to answer "Yes."
 ---
 id: two or more noncontinuous incidents
 question: |
@@ -3421,7 +3439,7 @@ question: |
   % if respondent_sexual_assault_conviction:
   Sexual assault conviction case number
   % else:
-  Obscene materials conviction case number
+  Obscene material conviction case number
   % endif
 subquestion: |
   Leave blank if unknown.
@@ -3448,13 +3466,13 @@ question: |
   % if respondent_sexual_assault_conviction:
   Court and county of sexual assault conviction
   % else:
-  Court and county of obscene materials conviction
+  Court and county of obscene material conviction
   % endif
 subquestion: |
   % if respondent_sexual_assault_conviction:
   Enter the name of the court and county where the sexual assault case was filed, if known.
   % else:
-  Enter the name of the court and county where the obscene materials case was filed, if known.
+  Enter the name of the court and county where the obscene material case was filed, if known.
   % endif
 fields:
   - Court name: orders_judgments[0].court_name
@@ -3593,7 +3611,7 @@ fields:
   - note: |
         Please add a **date or timeframe** to your explanation above. ${ incident_date_explained }
 
-        Once you add a date or timeframe, update your answer to the last question above to "Yes". Then tap **${MLH_continue_button_label}**
+        Once you add a date or timeframe, update your answer to the last question above to "Yes". Then tap **${MLH_continue_button_label}**.
     show if:
       variable: dates_check
       is: False
@@ -3629,7 +3647,7 @@ fields:
     show if:
       variable: respondent_sexual_assault_conviction
       is: True
-  - Was ${ other_parties[0].name } convicted of giving obscene material to you?: obscene_material_conviction
+  - Was ${ other_parties[0].name } convicted of giving {obscene material} to you?: obscene_material_conviction
     datatype: yesnoradio
     show if: 
       variable: respondent_sexual_assault_conviction
@@ -3649,7 +3667,7 @@ fields:
     show if:
       variable: fears_future_sexual_assault
       is: True
-  - Did ${ other_parties[0].name } give you obscene material?: obscene_material_provided
+  - Did ${ other_parties[0].name } give you {obscene material}?: obscene_material_provided
     datatype: yesnoradio
     show if: 
       variable: fears_future_sexual_assault
@@ -3671,7 +3689,7 @@ fields:
   - note: |
         Please add a **date or timeframe** to your explanation above. ${ incident_date_explained }
 
-        Once you add a date or timeframe, update your answer to the last question above to "Yes". Then tap **${MLH_continue_button_label}**
+        Once you add a date or timeframe, update your answer to the last question above to "Yes". Then tap **${MLH_continue_button_label}**.
     show if:
       variable: dates_check
       is: False

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -2395,11 +2395,25 @@ content: |
 
       A nondomestic personal protection order is used to protect someone from stalking or harassing behavior.
 ---
-id: sexual assault facts
+id: sexual assault facts (adult)
+if: not petitioner_is_minor
 question: |
   Sexual assault 
 fields:
   - "Has the {respondent} sexually assaulted you or threatened to sexually assault you?": sexual_assault_facts
+    datatype: yesnoradio
+  - note: |
+      OK, you will fill out the forms to request a **Nondomestic Sexual Assault** PPO.
+    show if:
+      variable: sexual_assault_facts
+      is: True
+---
+id: sexual assault facts (minor)
+if: petitioner_is_minor
+question: |
+  Sexual assault or obscene materials
+fields:
+  - "Has the {respondent} sexually assaulted you, threatened to sexually assault you, or given you obscene materials?": sexual_assault_facts
     datatype: yesnoradio
   - note: |
       OK, you will fill out the forms to request a **Nondomestic Sexual Assault** PPO.
@@ -3560,7 +3574,7 @@ fields:
     show if: 
       variable: respondent_sexual_assault_conviction
       is: False
-  - "Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }. Include a date or timeframe for all incidents.": potential_sexual_assault_exp
+  - "Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }. Include a date or timeframe.": potential_sexual_assault_exp
     input type: area
     show if:
       variable: fears_future_sexual_assault
@@ -3571,19 +3585,17 @@ fields:
     show if:
       variable: fears_future_sexual_assault
       is: True
-  - Did you include dates or timeframes in your explanation above?: sexual_assault_dates_check
+  - Did you include a date or timeframe in your explanation above?: dates_check
     datatype: yesnoradio
     show if:
       variable: fears_future_sexual_assault
       is: True
   - note: |
-        Please include dates or timeframes in your explanation above.
-        
-        Fill in the exact date if you know it. Otherwise, be as specific as you can, but don't guess. It is okay to give an approximate date or time or to put a time of year, like "last summer" or "Christmas time ${ today().year - 2 }."
+        Please add a **date or timeframe** to your explanation above. ${ incident_date_explained }
 
-        Once you add dates or timeframes, please update your answer to the last question above. Then you will be able to continue.
+        Once you add a date or timeframe, update your answer to the last question above to "Yes". Then tap **${MLH_continue_button_label}**
     show if:
-      variable: sexual_assault_dates_check
+      variable: dates_check
       is: False
   - note: |
         We're sorry, you cannot use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
@@ -3602,8 +3614,8 @@ fields:
 validation code: |
   if not respondent_sexual_assault_conviction and not fears_future_sexual_assault:
     validation_error("You can't continue unless one of these things is true.")
-  elif not respondent_sexual_assault_conviction and not sexual_assault_dates_check:
-    validation_error("You must include dates or timeframes. Once you add dates or timeframes, update your answer to the final question on this page to continue.")
+  elif not respondent_sexual_assault_conviction and not dates_check:
+    validation_error("Please add a date or timeframe to your explanation. Then select 'Yes' to continue.", field="dates_check")
 ---
 id: respondent sexual assault basis, minor petitioner
 if: petitioner_is_minor
@@ -3632,7 +3644,7 @@ fields:
     show if: 
       variable: obscene_material_conviction
       is: False
-  - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }.: potential_sexual_assault_exp
+  - "Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }. Include a date or timeframe.": potential_sexual_assault_exp
     input type: area
     show if:
       variable: fears_future_sexual_assault
@@ -3642,21 +3654,27 @@ fields:
     show if: 
       variable: fears_future_sexual_assault
       is: False
-  - Please explain what happened.: obscene_material_exp
+  - Please explain what happened. Include a date or timeframe.: obscene_material_exp
     input type: area
     show if:
       variable: obscene_material_provided
       is: True
   - note: |
+      ${ collapse_template(incident_date_explained) }
       ${ collapse_template(fears_future_sexual_assault_explained) }
-    show if:
-      variable: fears_future_sexual_assault
-      is: True
+    js show if:
+      val("fears_future_sexual_assault") == true || val("obscene_material_provided") == true
+  - Did you include a date or timeframe in your explanation above?: dates_check
+    datatype: yesnoradio
+    js show if:
+      val("fears_future_sexual_assault") == true || val("obscene_material_provided") == true
   - note: |
-      ${ collapse_template(fears_future_sexual_assault_explained) }
+        Please add a **date or timeframe** to your explanation above. ${ incident_date_explained }
+
+        Once you add a date or timeframe, update your answer to the last question above to "Yes". Then tap **${MLH_continue_button_label}**
     show if:
-      variable: obscene_material_provided
-      is: True
+      variable: dates_check
+      is: False
   - note: |
         We're sorry, you cannot use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
 
@@ -3674,12 +3692,16 @@ fields:
 validation code: |
   if not respondent_sexual_assault_conviction and not obscene_material_conviction and not fears_future_sexual_assault and not obscene_material_provided:
     validation_error("You can't continue unless one of these things is true.")
+  elif not respondent_sexual_assault_conviction and not obscene_material_conviction and not dates_check:
+    validation_error("Please add a date or timeframe to your explanation. Then select 'Yes' to continue.", field="dates_check")
 ---
 template: fears_future_sexual_assault_explained
 subject: |
-  More information about how to answer these questions.
+  More information about how to answer this question.
 content: |
-  Be as specific as you can about facts like locations. 
+  One incident is enough to ask for a personal protection order (PPO). If there has been more than one incident, please include them all, with dates or timeframes. 
+  
+  Be as specific as you can about facts like dates and locations. However, if you are not sure of a fact, do not guess. Instead, describe it as well as you can.  
 
   If you have any documents you want to show the judge, such as police reports, medical records, photos, copies of letters, texts, or email messages, you can attach copies to your petition. However, this is not necessary. The judge shouldn't deny a petition just because you don't have any documents to attach.
 ---
@@ -3817,7 +3839,7 @@ template: incident_date_explained
 subject: |
   Do I need an exact date?
 content: |
-  Fill in the exact date if you know it. Otherwise, be as specific as you can, but don't guess. It is okay to give an approximate date or time or to put a time of year, like "last summer" or "Christmas time ${ today().year - 2 }."
+  Give the exact date if you know it. Otherwise, be as specific as you can, but don't guess. It is okay to give an approximate date or time or to put a time of year, like "last summer" or "Christmas time ${ today().year - 2 }."
 ---
 id: incidents location
 question: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1806,7 +1806,7 @@ fields:
     datatype: radio
     choices:
       - I need a PPO to protect **myself**.: False
-      - I am the **power of attorney or legal guardian** for an **adult** who needs a PPO. I will apply and sign the petition for them.: True
+      - I am the **legal guardian or power of attorney** for an **adult** who needs a PPO. I will apply and sign the petition for them.: True
         help: |
           Choose this answer if the person who needs protection is an **adult** and:
           

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1806,28 +1806,28 @@ fields:
     datatype: radio
     choices:
       - I need a PPO to protect **myself**.: False
-      - "A **legally incapacitated adult** needs a PPO, and I am their guardian or power of attorney.": True
+      - I am the **legal guardian or power of attorney** for an **adult** who needs a PPO. I will apply and sign the petition for them.: True
+        help: |
+          Choose this answer if the person who needs protection is an **adult** and:
+          
+          * they signed a valid **power of attorney** form that allows you to file for them, or
+          * they are unable to make their own informed decisions and you have a valid **guardianship** order.
       - "**Someone else** (child or adult) needs a PPO and I'm helping them.": False
-  - note: |
-      ${ collapse_template(incapacitated_adult_explained) }
-  - Do you have authority to file a PPO petition for the legally incapacitated adult?: next_friends.there_are_any
+  - Do you have authority to file a PPO petition for this adult?: next_friends.there_are_any
     datatype: radio
     choices:
-      - Yes, I was named the person's guardian by court order.: True
-      - Yes, I have a power of attorney that allows me to file for the person.: True
+      - Yes, I was named their **guardian** by court order.: True
+      - Yes, I have a **power of attorney** that allows me to file for them.: True
       - Neither of these applies.: False
     show if:
       variable: is_incapacitated_adult
       is: True
     label above field: True
----
-template: incapacitated_adult_explained
-subject: |
-  What does "legally incapacitated adult" mean?
-content: |
-  An adult can become a "legally incapacitated adult" if they are unable to make their own informed decisions due to mental or physical illness or disability, or other causes. There must be a **court order** appointing a guardian or saying that they are incapacitated.
-  
-  Only a legal guardian or someone with a valid Power of Attorney can file a PPO petition on behalf of a legally incapacitated adult.
+  - note: |
+      **You must attach** guardianship or power of attorney paperwork to the petition.
+    show if:
+      variable: next_friends.there_are_any
+      is: True
 ---
 id: unauthorized to file for legally incapacitated adult kickout
 event: unauthorized_to_file_for_lii_kickout

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1183,9 +1183,17 @@ sets:
   - users[0].name.suffix
 question: |
   Enter your name
+subquestion: |
+  ${ collapse_template(what_if_helper) }
 fields:
   - code: |
       users[0].name_fields()
+---
+template: what_if_helper
+subject: |
+  What if I'm helping someone else fill this out?
+content: |
+  When a question says “you” or "your", it refers to the person who needs the PPO, NOT the helper. So in this case, enter the name of the person who needs the PPO.
 ---
 id: petitioner alias
 sets:
@@ -1792,15 +1800,22 @@ fields:
 ---
 id: is petitioner legally incapacitated adult
 question: |
-  Legally incapacitated adult
+  Who needs protection?
 fields:
-  - Will you be filing this PPO petition on behalf of a legally incapacitated adult?: is_incapacitated_adult
-    datatype: yesnoradio
-    label above field: True
+  - Who needs a personal protection order (PPO)?: is_incapacitated_adult
+    datatype: radio
+    choices:
+      - I need a PPO to protect **myself**.: False
+      - "A **legally incapacitated adult** needs a PPO, and I am their guardian or power of attorney.": True
+      - "**Someone else** (child or adult) needs a PPO and I'm helping them.": False
   - note: |
       ${ collapse_template(incapacitated_adult_explained) }
-  - Have you been named the guardian of this person by court order **OR** do you have a power of attorney that allows you to file for them?: next_friends.there_are_any
-    datatype: yesnoradio
+  - Do you have authority to file a PPO petition for the legally incapacitated adult?: next_friends.there_are_any
+    datatype: radio
+    choices:
+      - Yes, I was named the person's guardian by court order.: True
+      - Yes, I have a power of attorney that allows me to file for the person.: True
+      - Neither of these applies.: False
     show if:
       variable: is_incapacitated_adult
       is: True
@@ -1808,13 +1823,11 @@ fields:
 ---
 template: incapacitated_adult_explained
 subject: |
-  What does this mean?
+  What does "legally incapacitated adult" mean?
 content: |
-  Answer "Yes" if the person who **needs protection** is a legally incapacitated adult.
-
-  A legally incapacitated adult is an adult who is unable to make their own informed decisions due to mental or physical illness or disability, or other causes. Only a legal guardian or someone with a valid Power of Attorney can file a PPO petition on behalf of a legally incapacitated adult.
+  An adult can become a "legally incapacitated adult" if they are unable to make their own informed decisions due to mental or physical illness or disability, or other causes. There must be a **court order** appointing a guardian or saying that they are incapacitated.
   
-  Answer "No" if you want a PPO to protect yourself, or if you are helping a child fill this out.
+  Only a legal guardian or someone with a valid Power of Attorney can file a PPO petition on behalf of a legally incapacitated adult.
 ---
 id: unauthorized to file for legally incapacitated adult kickout
 event: unauthorized_to_file_for_lii_kickout

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -1806,7 +1806,7 @@ fields:
     datatype: radio
     choices:
       - I need a PPO to protect **myself**.: False
-      - I am the **legal guardian or power of attorney** for an **adult** who needs a PPO. I will apply and sign the petition for them.: True
+      - I am the **power of attorney or legal guardian** for an **adult** who needs a PPO. I will apply and sign the petition for them.: True
         help: |
           Choose this answer if the person who needs protection is an **adult** and:
           
@@ -1843,11 +1843,11 @@ subquestion: |
 id: inconsistent age kickout
 event: inconsistent_age_kickout
 question: |
-  You cannot continue using this tool
+  Is ${ users[0] } an adult or a minor?
 subquestion: |
-  You previously indicated you were filling out this form on behalf of an incapacitated **adult**, but the date you entered for ${ users[0] }'s birthday makes them a **minor**.
+  You previously said you were filling out this form on behalf of an **adult**, but you entered an age younger than 18 for ${ users[0] }.
 
-  If you made a mistake, tap the **${ MLH_back_button_label }** button to go back and change your answers.
+  Please start over or use the **${ MLH_back_button_label }** button to go back and change your answers.
 ---
 id: continue as next friend for incapacitated adult
 question: |

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -3560,16 +3560,31 @@ fields:
     show if: 
       variable: respondent_sexual_assault_conviction
       is: False
-  - Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }.: potential_sexual_assault_exp
+  - "Please explain what happened that made you afraid of being sexually assaulted by ${ other_parties[0].name }. Include a date or timeframe for all incidents.": potential_sexual_assault_exp
     input type: area
     show if:
       variable: fears_future_sexual_assault
       is: True
   - note: |
+      ${ collapse_template(incident_date_explained) }
       ${ collapse_template(fears_future_sexual_assault_explained) }
     show if:
       variable: fears_future_sexual_assault
       is: True
+  - Did you include dates or timeframes in your explanation above?: sexual_assault_dates_check
+    datatype: yesnoradio
+    show if:
+      variable: fears_future_sexual_assault
+      is: True
+  - note: |
+        Please include dates or timeframes in your explanation above.
+        
+        Fill in the exact date if you know it. Otherwise, be as specific as you can, but don't guess. It is okay to give an approximate date or time or to put a time of year, like "last summer" or "Christmas time ${ today().year - 2 }."
+
+        Once you add dates or timeframes, please update your answer to the last question above. Then you will be able to continue.
+    show if:
+      variable: sexual_assault_dates_check
+      is: False
   - note: |
         We're sorry, you cannot use this tool to prepare a nondomestic sexual assault *Personal Protection Order*.
 
@@ -3587,6 +3602,8 @@ fields:
 validation code: |
   if not respondent_sexual_assault_conviction and not fears_future_sexual_assault:
     validation_error("You can't continue unless one of these things is true.")
+  elif not respondent_sexual_assault_conviction and not sexual_assault_dates_check:
+    validation_error("You must include dates or timeframes. Once you add dates or timeframes, update your answer to the final question on this page to continue.")
 ---
 id: respondent sexual assault basis, minor petitioner
 if: petitioner_is_minor
@@ -3660,9 +3677,9 @@ validation code: |
 ---
 template: fears_future_sexual_assault_explained
 subject: |
-  More information about how to answer this question.
+  More information about how to answer these questions.
 content: |
-  Be as specific as you can about facts like dates and locations. However, if you are not sure of a date or other fact, do not guess. It is okay to give an approximate date or time, or to put a time of year, like "last summer."
+  Be as specific as you can about facts like locations. 
 
   If you have any documents you want to show the judge, such as police reports, medical records, photos, copies of letters, texts, or email messages, you can attach copies to your petition. However, this is not necessary. The judge shouldn't deny a petition just because you don't have any documents to attach.
 ---

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -20,7 +20,7 @@ review:
       ${ start_accordion('<h2 class="h5">Petitioner (you)</h2>') }
     show if: is_incapacitated_adult or not is_incapacitated_adult
   - note: |
-      The person who needs a PPO is an **incapacitated adult**. *(If you need to change this, please start over from the beginning.)*
+      A **guardian or power of attorney** is filing on behalf of ${ users[0] }. *(If you need to change this, please start over from the beginning.)*
     show if: is_incapacitated_adult
   - note: |
       You are an **emancipated** minor. *(If you need to change this, please start over from the beginning.)*

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -20,10 +20,10 @@ review:
       ${ start_accordion('<h2 class="h5">Petitioner (you)</h2>') }
     show if: is_incapacitated_adult or not is_incapacitated_adult
   - note: |
-      The person who needs a PPO is an **incapacitated adult**. *(If you need to change this, please use the **Undo** button or start over from the beginning.)*
+      The person who needs a PPO is an **incapacitated adult**. *(If you need to change this, please start over from the beginning.)*
     show if: is_incapacitated_adult
   - note: |
-      You are an **emancipated** minor. *(If you need to change this, please use the **Undo** button or start over from the beginning.)*
+      You are an **emancipated** minor. *(If you need to change this, please start over from the beginning.)*
     show if: petitioner_is_emancipated_minor
   - Edit: 
       - users[0].name.first
@@ -96,7 +96,7 @@ review:
       ${ next_accordion('<h2 class="h5">Respondent</h2>') }
     show if: respondent_lives_in_michigan or not respondent_lives_in_michigan
   - note: |
-      The respondent is an **emancipated** minor. *(If you need to change this, please use the **Undo** button or start over from the beginning.)*
+      The respondent is an **emancipated** minor. *(If you need to change this, please start over from the beginning.)*
     show if: respondent_is_emancipated_minor
   - Edit: 
       - other_parties[0].name.first
@@ -565,7 +565,7 @@ review:
       % elif ppo_type == "nondomestic_sexual_assault":
       **non-domestic sexual assault**
       % endif
-      PPO. To change the petition type, use the **Undo** button or start over.
+      PPO. To change the petition type, please start over from the beginning.
       % endif
   - Edit:
       - county_choice
@@ -1475,13 +1475,13 @@ template: user_turned_18
 subject: |
   What if I turned 18?
 content: |
-  If you turned 18, you need to use the **${ MLH_back_button_label }** button or start over. This is because there are different requirements for minor and adult petitioners. We're very sorry for the inconvenience. 
+  If you turned 18, you need to start over. This is because there are different requirements for minor and adult petitioners. We're very sorry for the inconvenience. 
 ---
 template: respondent_turned_18
 subject: |
   What if they turned 18?
 content: |
-  If the respondent turned 18, you need to use the **${ MLH_back_button_label }** button or start over. This is because there are different forms and requirements for minor and adult respondents. We're very sorry for the inconvenience. 
+  If the respondent turned 18, you need to start over. This is because there are different forms and requirements for minor and adult respondents. We're very sorry for the inconvenience. 
 ---
 id: user age emancipated minor
 if: users[0].age_in_years() < 18 and petitioner_is_emancipated_minor
@@ -1540,7 +1540,7 @@ fields:
 ---
 template: adult_OP_age_validation
 content: |
-  Earlier, you said the respondent was at least 18. If the respondent is a minor, please use the ${ MLH_back_button_label } button or start over.
+  Earlier, you said the respondent was at least 18. If the respondent is a minor, please start over.
 ---
 id: edit respondent birthdate minor
 if: other_parties[0].age_in_years() < 18 and not respondent_is_emancipated_minor
@@ -1588,7 +1588,7 @@ content: |
 ---
 template: minor_OP_max_age_validation
 content: |
-  Earlier, you said the respondent was UNDER 18. If the respondent is an adult, please use the ${ MLH_back_button_label } button or start over.
+  Earlier, you said the respondent was UNDER 18. If the respondent is an adult, please start over.
 ---
 id: edit respondent birthdate emancipated minor
 if: other_parties[0].age_in_years() < 18 and respondent_is_emancipated_minor
@@ -1660,5 +1660,5 @@ under: |
 template: what_if_no_domestic_relationship_review
 subject: What if none of these options apply?
 content: |
-  If none of these apply, use the **${ MLH_back_button_label }** button or start over. This is to make sure you fill out the right type of personal protection order (PPO) forms for your situation.
+  If none of these apply, please start over. This is to make sure you fill out the right type of personal protection order (PPO) forms for your situation.
 ---

--- a/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/review.yml
@@ -20,7 +20,7 @@ review:
       ${ start_accordion('<h2 class="h5">Petitioner (you)</h2>') }
     show if: is_incapacitated_adult or not is_incapacitated_adult
   - note: |
-      A **guardian or power of attorney** is filing on behalf of ${ users[0] }. *(If you need to change this, please start over from the beginning.)*
+      A **guardian or someone with a power of attorney** is filing on behalf of ${ users[0] }. *(If you need to change this, please start over from the beginning.)*
     show if: is_incapacitated_adult
   - note: |
       You are an **emancipated** minor. *(If you need to change this, please start over from the beginning.)*


### PR DESCRIPTION
Note: the goal (for time-saving purposes) was to address these issues without making major logic changes to the interview. That's why we stuck to more surface-level fixes in some cases.
- Fixes #527 by adding question checking if date/timeframe was given
- fixes #528 by updating the legally_incapacitated_individuals question and removing references to using "undo" button from uneditable variables to avoid confusion.
- also realized the PPO screening question (sexual_assault_facts) for SA petitions was missing a minor version referencing the "obscene material" prong, so we added that. 
- also noted "obscene material" could use definition, so added some help text. AB noted the statute is old and vague, so it's hard to give a great definition.