### PR TITLE
Replaced note with Edit field

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -4649,17 +4649,18 @@ review:
       % elif not exhibit_attachment.exhibits.has_exhibits:
       No
       % endif
-  - note: |
+  - Edit:
+      - exhibit_attachment.exhibits.revisit
+      - recompute:
+        - exhibit_attachment.table_of_contents
+    button: |
       **Uploaded Documents**
 
-      % if exhibit_attachment.exhibits.there_are_any:
+      % if exhibit_attachment.exhibits.number_gathered() > 0:
       ${ collapse_template(exhibit_attachment.exhibits.in_progress_exhibits) }
       % else:
       You have not uploaded any documents yet.
       % endif
-
-      ${ exhibit_attachment.exhibits.add_action() }
-
     css class: bg-secondary-subtle
     show if: exhibit_attachment.exhibits.has_exhibits
   - note: |


### PR DESCRIPTION
Fixed #529 

- Replaced `note: |` with `Edit:` field in final ETC review screen for uploaded documents. Also added recompute list to update the TOC template. This basically mimics the block in the main review screen that allows users to review/edit uploaded docs.
<img width="949" height="740" alt="Screenshot 2025-08-06 at 3 45 01 PM" src="https://github.com/user-attachments/assets/f01942d8-6ac3-4552-87a3-9a3e2b394557" />

1. Starting at the document review screen, the user be able to see their uploaded docs with the same collapse template inside a unique card. The card will now contain an Edit button in the top right corner.
<img width="733" height="839" alt="1" src="https://github.com/user-attachments/assets/8c3ef0e8-cbca-41a9-b95b-f70257907248" />

2. After clicking the Edit button, the user will access another screen, where they can add, delete, or rearrange documents. Same as with the main review screen, after clicking Continue, the TOC template file will be updated accordingly.
<img width="757" height="717" alt="2" src="https://github.com/user-attachments/assets/ef4e1102-0cc4-46a4-82d7-2a8231f92a2f" />