### PR TITLE
Displaying Continue and Undo buttons in Spanish

### DIFF
--- a/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
+++ b/docassemble/MLHPPOAndProposedOrder/data/questions/ppo_and_proposed_order.yml
@@ -59,6 +59,21 @@ code: |
 code: |
   al_interview_languages = ["en", "es"] 
 ---
+initial: true
+code: |
+  if get_language() == "es":
+    MLH_continue_button_label = "Continuar"
+    MLH_back_button_label = "Deshacer"
+  else:
+    MLH_continue_button_label = "Continue"
+    MLH_back_button_label = "Undo"
+
+  set_parts(
+    continue_button_label=MLH_continue_button_label,
+    back_button_label=MLH_back_button_label,
+    corner_back_button_label=MLH_back_button_label,
+  )
+---
 id: interview config code block
 code: |
   github_repo_name = 'docassemble-MLHPPOAndProposedOrder' if get_config('debug') else 'docassemble-UserFeedback'


### PR DESCRIPTION
- Added a code block to handle conditional logic for displaying Continue and Undo buttons in Spanish when the interview language is changed. Buttons now display Continuar and Deshacer, respectively. The Deshacher button differs slightly from the Undo button in that it's missing the grey/white styling (see image below for result).

<img width="899" height="632" alt="Screenshot 2026-07-30 at 1 59 52 PM" src="https://github.com/user-attachments/assets/4fb1ac00-a9bf-4cad-ba7e-9efd7c2e983d" />